### PR TITLE
fix(#31): set default version temporarily

### DIFF
--- a/.changeset/moody-rabbits-drum.md
+++ b/.changeset/moody-rabbits-drum.md
@@ -1,0 +1,5 @@
+---
+"@scalar/openapi-parser": patch
+---
+
+fix: make new parser behave like previous one on missing info.version

--- a/packages/openapi-parser/src/lib/Validator/Validator.ts
+++ b/packages/openapi-parser/src/lib/Validator/Validator.ts
@@ -52,6 +52,12 @@ export class Validator {
     // TODO: How does this work with a filesystem?
     this.specification = specification
 
+    // TODO: defaulting info.version to keep parser compatible with the previous one
+    // we should bubble this error up and not throw on it
+    if (this.specification?.info && !this.specification.info.version) {
+      this.specification.info.version = '0.0.1'
+    }
+
     try {
       // AnyObject is empty or invalid
       if (specification === undefined || specification === null) {


### PR DESCRIPTION
The previous parser never used to throw on missing info.version, however this one does. The spec DOES say info.version is required but we should bubble this error up and display it + continue to render the spec as it should not be blocking.

This PR is a very temp hot fix to get this parser to match the previous one's behavior. We should follow up and add a proper non-blocking, error bubbling strategy (if one does not exist).

closes #21 