### PR TITLE
refactor: resolve should resolve

### DIFF
--- a/.changeset/two-mangos-shake.md
+++ b/.changeset/two-mangos-shake.md
@@ -1,0 +1,5 @@
+---
+"@scalar/openapi-parser": patch
+---
+
+refactor: resolve should resolve (and not validate)

--- a/packages/openapi-parser/src/lib/Validator/Validator.ts
+++ b/packages/openapi-parser/src/lib/Validator/Validator.ts
@@ -92,24 +92,12 @@ export class Validator {
       }
 
       // Check if the references are valid
-      if (schemaResult) {
-        const resolvedReferences = resolveReferences(filesystem)
+      const resolvedReferences = resolveReferences(filesystem)
 
-        if (resolvedReferences.errors.length > 0) {
-          return {
-            valid: false,
-            errors: resolvedReferences.errors,
-          }
-        } else {
-          return {
-            ...resolvedReferences,
-          }
-        }
-      }
-
-      // Whoops … no errors? Actually, that should never happen.
       return {
-        valid: false,
+        valid: schemaResult && resolvedReferences.valid,
+        errors: [...(schemaResult.errors ?? []), ...resolvedReferences.errors],
+        schema: resolvedReferences.schema,
       }
     } catch (error) {
       // Something went horribly wrong!

--- a/packages/openapi-parser/src/pipeline.test.ts
+++ b/packages/openapi-parser/src/pipeline.test.ts
@@ -162,10 +162,10 @@ describe('pipeline', () => {
 
   it('validate + resolve', async () => {
     const validation = await openapi().load(specification).validate()
-    const result = await validation.resolve()
+    expect(validation.valid).toBe(true)
 
+    const result = await validation.resolve()
     expect(result.errors).toStrictEqual([])
-    expect(result.valid).toBe(true)
     expect(result.schema.info.title).toBe('Hello World')
   })
 })

--- a/packages/openapi-parser/src/types/index.ts
+++ b/packages/openapi-parser/src/types/index.ts
@@ -19,6 +19,7 @@ export type ValidateResult = {
   specification?: OpenAPI.Document
   version?: string
   errors?: ErrorObject[]
+  schema?: AnyObject | ResolvedOpenAPI.Document
 }
 
 export type ErrorObject = {
@@ -27,7 +28,6 @@ export type ErrorObject = {
 }
 
 export type ResolveResult = {
-  valid: boolean
   version: string | undefined
   specification?: OpenAPI.Document
   schema?: AnyObject | ResolvedOpenAPI.Document

--- a/packages/openapi-parser/src/utils/errors.test.ts
+++ b/packages/openapi-parser/src/utils/errors.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from 'vitest'
 
-import { resolve } from './resolve'
+import { validate } from './validate'
 
 describe('errors', () => {
   it('info required', async () => {
-    const result = await resolve({
+    const result = await validate({
       openapi: '3.1.0',
       paths: {},
     })
@@ -38,12 +38,9 @@ describe('errors', () => {
         },
       },
     }
-    const result = await resolve(spec)
+    const result = await validate(spec)
 
     expect(result).toMatchObject({
-      schema: {
-        ...spec,
-      },
       errors: [
         {
           message: `Property foobar is not expected to be here`,

--- a/packages/openapi-parser/src/utils/resolve.test.ts
+++ b/packages/openapi-parser/src/utils/resolve.test.ts
@@ -14,7 +14,6 @@ describe('resolve', async () => {
     }`)
 
     expect(result.errors).toStrictEqual([])
-    expect(result.valid).toBe(true)
     expect(result.schema.info.title).toBe('Hello World')
   })
 
@@ -29,7 +28,6 @@ describe('resolve', async () => {
     }`)
 
     expect(result.errors).toStrictEqual([])
-    expect(result.valid).toBe(true)
     expect(result.schema.info.title).toBe('Hello World')
   })
 
@@ -44,45 +42,6 @@ describe('resolve', async () => {
     }`)
 
     expect(result.errors).toStrictEqual([])
-    expect(result.valid).toBe(true)
-    expect(result.schema.info.title).toBe('Hello World')
-  })
-
-  it('doesn’t work with OpenAPI 4.0.0', async () => {
-    const result = await resolve(`{
-      "openapi": "4.0.0",
-      "info": {
-          "title": "Hello World",
-          "version": "1.0.0"
-      },
-      "paths": {}
-    }`)
-
-    expect(result.valid).toBe(false)
-    expect(result.errors).toHaveLength(1)
-    expect(result.errors[0].message).toContain(
-      'Cannot find supported Swagger/OpenAPI version in specification',
-    )
-  })
-
-  it('returns errors for an invalid specification', async () => {
-    const result = await resolve('pineapples')
-
-    expect(result.valid).toBe(false)
-    expect(result.errors).toHaveLength(1)
-    expect(result.errors[0].message).toBe(
-      'Cannot find supported Swagger/OpenAPI version in specification, version must be a string.',
-    )
-  })
-
-  it('works with YAML', async () => {
-    const result = await resolve(`openapi: 3.1.0
-info:
-  title: Hello World
-  version: 1.0.0
-paths: {}
-`)
-
     expect(result.schema.info.title).toBe('Hello World')
   })
 
@@ -97,7 +56,6 @@ paths: {}
     }`)
 
     expect(result.errors).toStrictEqual([])
-    expect(result.valid).toBe(true)
     expect(result.version).toBe('3.1')
   })
 
@@ -112,7 +70,6 @@ paths: {}
     }`)
 
     expect(result.errors).toStrictEqual([])
-    expect(result.valid).toBe(true)
     expect(result.version).toBe('3.0')
   })
 
@@ -127,7 +84,6 @@ paths: {}
     }`)
 
     expect(result.errors).toStrictEqual([])
-    expect(result.valid).toBe(true)
     expect(result.version).toBe('2.0')
   })
 
@@ -141,7 +97,6 @@ paths: {}
       "paths": {}
     }`)
 
-    expect(result.valid).toBe(false)
     expect(result.version).toBe(undefined)
   })
 })
@@ -189,7 +144,6 @@ it('resolves a simple reference', async () => {
   const result = await resolve(openapi)
 
   expect(result.errors).toStrictEqual([])
-  expect(result.valid).toBe(true)
 
   // Original
   expect(

--- a/packages/openapi-parser/src/utils/resolveReferences.test.ts
+++ b/packages/openapi-parser/src/utils/resolveReferences.test.ts
@@ -649,9 +649,7 @@ describe('resolveReferences', () => {
 
     const { schema } = resolveReferences(filesystem)
 
-    // TODO: Resolve the *path* from the given file
-    // console.log('RESULT', schema.schema.components.schemas.Upload)
-    // @ts-ignore
-    // expect(schema.components.schemas.Upload.allOf[0].title).toBe('Coordinates')
+    // Resolve the *path* from the given file
+    expect(schema.components.schemas.Upload.allOf[0].title).toBe('Coordinates')
   })
 })

--- a/packages/openapi-parser/src/utils/validate.test.ts
+++ b/packages/openapi-parser/src/utils/validate.test.ts
@@ -31,4 +31,40 @@ describe('validate', async () => {
       message: "must have required property 'info'",
     })
   })
+
+  it('returns errors for an invalid specification', async () => {
+    const result = await validate('pineapples')
+
+    expect(result.errors).toHaveLength(1)
+    expect(result.errors[0].message).toBe(
+      'Cannot find supported Swagger/OpenAPI version in specification, version must be a string.',
+    )
+  })
+
+  it('works with YAML', async () => {
+    const result = await validate(`openapi: 3.1.0
+info:
+  title: Hello World
+  version: 1.0.0
+paths: {}
+`)
+
+    expect(result.schema.info.title).toBe('Hello World')
+  })
+
+  it('doesn’t work with OpenAPI 4.0.0', async () => {
+    const result = await validate(`{
+      "openapi": "4.0.0",
+      "info": {
+          "title": "Hello World",
+          "version": "1.0.0"
+      },
+      "paths": {}
+    }`)
+
+    expect(result.errors).toHaveLength(1)
+    expect(result.errors[0].message).toContain(
+      'Cannot find supported Swagger/OpenAPI version in specification',
+    )
+  })
 })

--- a/packages/openapi-parser/tests/diff.test.ts
+++ b/packages/openapi-parser/tests/diff.test.ts
@@ -7,11 +7,11 @@ import { describe, expect, test } from 'vitest'
 import { AnyObject, normalize, openapi } from '../src'
 
 const expectedErrors = {
-  'packages/openapi-parser/tests/files/airport-webappspotcom.yaml': [
-    {
-      message: "must have required property 'tokenUrl'",
-    },
-  ],
+  // 'packages/openapi-parser/tests/files/airport-webappspotcom.yaml': [
+  //   {
+  //     message: "must have required property 'tokenUrl'",
+  //   },
+  // ],
   'packages/openapi-parser/tests/files/opensuseorgobs.yaml': [
     {
       message: "must have required property '$ref'",
@@ -102,25 +102,16 @@ describe('diff', async () => {
       console.error('[@apidevtools/swagger-parser]', error.message)
     })) as any
 
-    const {
-      schema: newSchema,
-      valid,
-      errors,
-    } = await openapi().load(structuredClone(specification)).resolve()
+    const { schema: newSchema, errors } = await openapi()
+      .load(structuredClone(specification))
+      .resolve()
 
     // Errors expected
     if (expectedErrors[file]) {
       expect(errors).toMatchObject(expectedErrors[file])
-      expect(valid).toBe(false)
     }
     // No errors expected
     else {
-      // Valid?
-      if (!valid) {
-        console.log(errors)
-      }
-      expect(valid).toBe(true)
-
       // Same number of paths? Or even more?
       expect(Object.keys(oldSchema?.paths ?? {}).length).toBeLessThanOrEqual(
         Object.keys(newSchema?.paths ?? {}).length,

--- a/packages/openapi-parser/tests/filesystem.test.ts
+++ b/packages/openapi-parser/tests/filesystem.test.ts
@@ -24,8 +24,6 @@ describe('filesystem', async () => {
 
     const result = await resolve(filesystem)
 
-    expect(result.valid).toBe(true)
-
     expect(result.errors).toStrictEqual([])
     expect(result.version).toBe('3.0')
     // Resolve the *path* from the given file

--- a/packages/openapi-parser/tests/openapi3-examples/3.0/fail/OAI/OAI.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.0/fail/OAI/OAI.test.ts
@@ -1,13 +1,13 @@
 import { describe, expect, it } from 'vitest'
 
-import { resolve } from '../../../../../src'
+import { validate } from '../../../../../src'
 import apiWithExamples from './api-with-examples.yaml'
 
 // TODO: The example is in the `fail` folder, but I don’t know why it’s supposed to fail.
 // I think the YAML is just wrong ("YAMLException: deficient indentation"), but we can’t test this with an import.
 describe.todo('OAI', () => {
   it('apiWithExamples', async () => {
-    const result = await resolve(apiWithExamples)
+    const result = await validate(apiWithExamples)
 
     expect(result.errors?.[0]?.message).toBe(`something went wrong`)
     expect(result.valid).toBe(false)

--- a/packages/openapi-parser/tests/openapi3-examples/3.0/fail/api-with-examples.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.0/fail/api-with-examples.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
-import { resolve } from '../../../../src'
+import { validate } from '../../../../src'
 import apiWithExamples from './api-with-examples.yaml'
 
 describe('api-with-examples', () => {
   it('returns an error', async () => {
-    const result = await resolve(apiWithExamples)
+    const result = await validate(apiWithExamples)
 
     // TODO: Swagger Editor:
     //

--- a/packages/openapi-parser/tests/openapi3-examples/3.0/fail/comp_pathitems.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.0/fail/comp_pathitems.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
-import { resolve } from '../../../../src'
+import { validate } from '../../../../src'
 import comp_pathitems from './comp_pathitems.yaml'
 
 describe('comp_pathitems', () => {
   it('returns an error', async () => {
-    const result = await resolve(comp_pathitems)
+    const result = await validate(comp_pathitems)
 
     // TODO: Should probably complain about the pathItems?
     expect(result.errors?.[0]?.message).toBe(

--- a/packages/openapi-parser/tests/openapi3-examples/3.0/fail/deprecated.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.0/fail/deprecated.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
-import { resolve } from '../../../../src'
+import { validate } from '../../../../src'
 import deprecated from './deprecated.yaml'
 
 describe('deprecated', () => {
   it('returns an error', async () => {
-    const result = await resolve(deprecated)
+    const result = await validate(deprecated)
 
     expect(result.errors?.[0]?.message).toBe(`: type must be boolean`)
     expect(result.errors?.length).toBe(1)

--- a/packages/openapi-parser/tests/openapi3-examples/3.0/fail/deprecated2.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.0/fail/deprecated2.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
-import { resolve } from '../../../../src'
+import { validate } from '../../../../src'
 import deprecated2 from './deprecated2.yaml'
 
 describe.todo('deprecated2', () => {
   it('returns an error', async () => {
-    const result = await resolve(deprecated2)
+    const result = await validate(deprecated2)
 
     expect(result.errors?.[0]?.message).toBe(`something something deprecated`)
     expect(result.errors?.length).toBe(1)

--- a/packages/openapi-parser/tests/openapi3-examples/3.0/fail/deprecated3.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.0/fail/deprecated3.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
-import { resolve } from '../../../../src'
+import { validate } from '../../../../src'
 import deprecated3 from './deprecated3.yaml'
 
 describe.todo('deprecated3', () => {
   it('returns an error', async () => {
-    const result = await resolve(deprecated3)
+    const result = await validate(deprecated3)
 
     expect(result.errors?.[0]?.message).toBe(`something something deprecated`)
     expect(result.errors?.length).toBe(1)

--- a/packages/openapi-parser/tests/openapi3-examples/3.0/fail/duplicateOperationId.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.0/fail/duplicateOperationId.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
-import { resolve } from '../../../../src'
+import { validate } from '../../../../src'
 import duplicateOperationId from './duplicateOperationId.yaml'
 
 describe.todo('duplicateOperationId', () => {
   it('returns an error', async () => {
-    const result = await resolve(duplicateOperationId)
+    const result = await validate(duplicateOperationId)
 
     expect(result.errors?.[0]?.message).toBe(
       `something something duplicate operationId`,

--- a/packages/openapi-parser/tests/openapi3-examples/3.0/fail/duplicateParameter.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.0/fail/duplicateParameter.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
-import { resolve } from '../../../../src'
+import { validate } from '../../../../src'
 import duplicateParameter from './duplicateParameter.yaml'
 
 describe.todo('duplicateParameter', () => {
   it('returns an error', async () => {
-    const result = await resolve(duplicateParameter)
+    const result = await validate(duplicateParameter)
 
     expect(result.errors?.[0]?.message).toBe(
       `something something duplicate parameter`,

--- a/packages/openapi-parser/tests/openapi3-examples/3.0/fail/duplicateRequired.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.0/fail/duplicateRequired.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
-import { resolve } from '../../../../src'
+import { validate } from '../../../../src'
 import duplicateRequired from './duplicateRequired.yaml'
 
 describe.todo('duplicateRequired', () => {
   it('returns an error', async () => {
-    const result = await resolve(duplicateRequired)
+    const result = await validate(duplicateRequired)
 
     expect(result.errors?.[0]?.message).toBe(
       `something something duplicate required properties`,

--- a/packages/openapi-parser/tests/openapi3-examples/3.0/fail/event-backend/event-backend.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.0/fail/event-backend/event-backend.test.ts
@@ -1,13 +1,13 @@
 import { describe, expect, it } from 'vitest'
 
-import { resolve } from '../../../../../src'
+import { validate } from '../../../../../src'
 import openapi1 from './openapi1.json'
 import openapi2 from './openapi2.json'
 import openapi3 from './openapi3.json'
 
 describe('event-backend', () => {
   it('openapi1', async () => {
-    const result = await resolve(openapi1)
+    const result = await validate(openapi1)
 
     // TODO: What does that mean?
     expect(result.errors?.[0]?.message).toBe(
@@ -17,7 +17,7 @@ describe('event-backend', () => {
   })
 
   it('openapi2', async () => {
-    const result = await resolve(openapi2)
+    const result = await validate(openapi2)
 
     // TODO: What does that mean?
     expect(result.errors?.[0]?.message).toBe(
@@ -27,7 +27,7 @@ describe('event-backend', () => {
   })
 
   it('openapi3', async () => {
-    const result = await resolve(openapi3)
+    const result = await validate(openapi3)
 
     // TODO: What does that mean?
     expect(result.errors?.[0]?.message).toBe(

--- a/packages/openapi-parser/tests/openapi3-examples/3.0/fail/hasFlowNotFlows.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.0/fail/hasFlowNotFlows.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
-import { resolve } from '../../../../src'
+import { validate } from '../../../../src'
 import hasFlowNotFlows from './hasFlowNotFlows.json'
 
 describe('hasFlowNotFlows', () => {
   it('returns an error', async () => {
-    const result = await resolve(hasFlowNotFlows)
+    const result = await validate(hasFlowNotFlows)
 
     // TODO: This should probably mention the incorrect security type?
     expect(result.errors?.[0]?.message).toBe(

--- a/packages/openapi-parser/tests/openapi3-examples/3.0/fail/incorrectSecType.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.0/fail/incorrectSecType.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
-import { resolve } from '../../../../src'
+import { validate } from '../../../../src'
 import incorrectSecType from './incorrectSecType.json'
 
 describe('incorrectSecType', () => {
   it('returns an error', async () => {
-    const result = await resolve(incorrectSecType)
+    const result = await validate(incorrectSecType)
 
     // TODO: Shouldn’t this metnion the incorrect security type?
     expect(result.errors?.[0]?.message).toBe(

--- a/packages/openapi-parser/tests/openapi3-examples/3.0/fail/info_summary.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.0/fail/info_summary.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
-import { resolve } from '../../../../src'
+import { validate } from '../../../../src'
 import info_summary from './info_summary.yaml'
 
 describe('info_summary', () => {
   it('returns an error', async () => {
-    const result = await resolve(info_summary)
+    const result = await validate(info_summary)
 
     expect(result.errors?.[0]?.message).toBe(
       'Property summary is not expected to be here',

--- a/packages/openapi-parser/tests/openapi3-examples/3.0/fail/internalPathItemRef.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.0/fail/internalPathItemRef.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
-import { resolve } from '../../../../src'
+import { validate } from '../../../../src'
 import internalPathItemRef from './internalPathItemRef.yaml'
 
 describe('internalPathItemRef', () => {
   it('returns an error', async () => {
-    const result = await resolve(internalPathItemRef)
+    const result = await validate(internalPathItemRef)
 
     // expect(result.errors?.[0]?.message).toBe(`Can’t resolve URI: #/paths/test2`)
     // expect(result.errors?.length).toBe(1)

--- a/packages/openapi-parser/tests/openapi3-examples/3.0/fail/invalidPattern.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.0/fail/invalidPattern.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
-import { resolve } from '../../../../src'
+import { validate } from '../../../../src'
 import invalidPattern from './invalidPattern.yaml'
 
 describe('invalidPattern', () => {
   it('returns an error', async () => {
-    const result = await resolve(invalidPattern)
+    const result = await validate(invalidPattern)
 
     // TODO: Swagger Editor
     //

--- a/packages/openapi-parser/tests/openapi3-examples/3.0/fail/invalidSchema.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.0/fail/invalidSchema.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
-import { resolve } from '../../../../src'
+import { validate } from '../../../../src'
 import invalidSchema from './invalidSchema.json'
 
 describe('invalidSchema', () => {
   it('returns an error', async () => {
-    const result = await resolve(invalidSchema)
+    const result = await validate(invalidSchema)
 
     // TODO: Swagger Editor
     //

--- a/packages/openapi-parser/tests/openapi3-examples/3.0/fail/invalidSchemaName.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.0/fail/invalidSchemaName.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
-import { resolve } from '../../../../src'
+import { validate } from '../../../../src'
 import invalidSchemaName from './invalidSchemaName.json'
 
 describe('invalidSchemaName', () => {
   it('returns an error', async () => {
-    const result = await resolve(invalidSchemaName)
+    const result = await validate(invalidSchemaName)
 
     // TODO: Swagger Editor
     //

--- a/packages/openapi-parser/tests/openapi3-examples/3.0/fail/license_identifier.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.0/fail/license_identifier.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
-import { resolve } from '../../../../src'
+import { validate } from '../../../../src'
 import license_identifier from './license_identifier.yaml'
 
 describe('license_identifier', () => {
   it('returns an error', async () => {
-    const result = await resolve(license_identifier)
+    const result = await validate(license_identifier)
 
     // TODO: Swagger Editor
     //

--- a/packages/openapi-parser/tests/openapi3-examples/3.0/fail/missingPathItemRef.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.0/fail/missingPathItemRef.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
-import { resolve } from '../../../../src'
+import { validate } from '../../../../src'
 import missingPathItemRef from './missingPathItemRef.yaml'
 
 describe.todo('missingPathItemRef', () => {
   it('returns an error', async () => {
-    const result = await resolve(missingPathItemRef)
+    const result = await validate(missingPathItemRef)
 
     // TODO: Swagger Editor
     //

--- a/packages/openapi-parser/tests/openapi3-examples/3.0/fail/missingPathParam.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.0/fail/missingPathParam.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
-import { resolve } from '../../../../src'
+import { validate } from '../../../../src'
 import missingPathParam from './missingPathParam.yaml'
 
 describe.todo('missingPathParam', () => {
   it('returns an error', async () => {
-    const result = await resolve(missingPathParam)
+    const result = await validate(missingPathParam)
 
     // TODO: Swagger Editor
     //

--- a/packages/openapi-parser/tests/openapi3-examples/3.0/fail/missingPathParam2.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.0/fail/missingPathParam2.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
-import { resolve } from '../../../../src'
+import { validate } from '../../../../src'
 import missingPathParam2 from './missingPathParam2.yaml'
 
 describe.todo('missingPathParam2', () => {
   it('returns an error', async () => {
-    const result = await resolve(missingPathParam2)
+    const result = await validate(missingPathParam2)
 
     // TODO: Swagger Editor
     //

--- a/packages/openapi-parser/tests/openapi3-examples/3.0/fail/openapi-ui/openapi-ui.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.0/fail/openapi-ui/openapi-ui.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
-import { resolve } from '../../../../../src'
+import { validate } from '../../../../../src'
 import openApiUi from './openapi-ui.yaml'
 
 describe('openapi-ui', () => {
   it('apiWithExamples', async () => {
-    const result = await resolve(openApiUi)
+    const result = await validate(openApiUi)
 
     // TODO: SwaggerUI has a more helpful error message:
     //

--- a/packages/openapi-parser/tests/openapi3-examples/3.0/fail/openapi-vue/openapi-vue.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.0/fail/openapi-vue/openapi-vue.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, it } from 'vitest'
 
-import { resolve } from '../../../../../src'
+import { validate } from '../../../../../src'
 import edit1 from './edit1.json'
 import openApiVue from './openapi.json'
 
 describe('openapi-vue', () => {
   it('openapi', async () => {
-    const result = await resolve(openApiVue)
+    const result = await validate(openApiVue)
 
     // TODO: SwaggerUI has a more helpful error message:
     //
@@ -20,7 +20,7 @@ describe('openapi-vue', () => {
   })
 
   it('edit1', async () => {
-    const result = await resolve(edit1)
+    const result = await validate(edit1)
 
     // TODO: SwaggerUI has a more helpful error message:
     //

--- a/packages/openapi-parser/tests/openapi3-examples/3.0/fail/pathitem-property.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.0/fail/pathitem-property.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
-import { resolve } from '../../../../src'
+import { validate } from '../../../../src'
 import pathitemProperty from './pathitem-property.yaml'
 
 describe('pathitem-property', () => {
   it('returns an error', async () => {
-    const result = await resolve(pathitemProperty)
+    const result = await validate(pathitemProperty)
 
     expect(result.errors?.[0]?.message).toBe(
       `Property GET is not expected to be here`,

--- a/packages/openapi-parser/tests/openapi3-examples/3.0/fail/refAsInteger.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.0/fail/refAsInteger.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
-import { resolve } from '../../../../src'
+import { validate } from '../../../../src'
 import refAsInteger from './refAsInteger.yaml'
 
 describe('refAsInteger', () => {
   it('returns an error', async () => {
-    const result = await resolve(refAsInteger)
+    const result = await validate(refAsInteger)
 
     // TODO: Swagger Editor
     //

--- a/packages/openapi-parser/tests/openapi3-examples/3.0/fail/schemaProperties.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.0/fail/schemaProperties.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
-import { resolve } from '../../../../src'
+import { validate } from '../../../../src'
 import schemaProperties from './schemaProperties.yaml'
 
 describe('schemaProperties', () => {
   it('returns an error', async () => {
-    const { valid, errors, schema } = await resolve(schemaProperties)
+    const { valid, errors, schema } = await validate(schemaProperties)
 
     expect(schema?.components?.schemas?.SomeObject).not.toBe(undefined)
 

--- a/packages/openapi-parser/tests/openapi3-examples/3.0/fail/serverVariableEnumType.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.0/fail/serverVariableEnumType.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
-import { resolve } from '../../../../src'
+import { validate } from '../../../../src'
 import serverVariableEnumType from './serverVariableEnumType.yaml'
 
 describe('serverVariableEnumType', () => {
   it('returns an error', async () => {
-    const result = await resolve(serverVariableEnumType)
+    const result = await validate(serverVariableEnumType)
 
     // TODO: Swagger Editor has a better error message
     //

--- a/packages/openapi-parser/tests/openapi3-examples/3.0/pass/cyclical.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.0/pass/cyclical.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { getListOfReferences, resolve } from '../../../../src'
+import { getListOfReferences, validate } from '../../../../src'
 
 describe('cyclical', () => {
   it('resolves circular references', async () => {
@@ -36,7 +36,7 @@ describe('cyclical', () => {
       },
     }
 
-    const result = await resolve(specification)
+    const result = await validate(specification)
 
     expect(result.valid).toBe(true)
     expect(result.version).toBe('3.0')
@@ -95,7 +95,7 @@ describe('cyclical', () => {
       },
     }
 
-    const result = await resolve([
+    const result = await validate([
       {
         isEntrypoint: true,
         specification: baseFile,

--- a/packages/openapi-parser/tests/openapi3-examples/3.0/pass/deprecated.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.0/pass/deprecated.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
-import { resolve } from '../../../../src'
+import { validate } from '../../../../src'
 import deprecated from './deprecated.yaml'
 
 describe('deprecated', () => {
   it('passes', async () => {
-    const result = await resolve(deprecated)
+    const result = await validate(deprecated)
 
     expect(result.valid).toBe(true)
     expect(result.version).toBe('3.0')

--- a/packages/openapi-parser/tests/openapi3-examples/3.0/pass/extensionsEverywhere.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.0/pass/extensionsEverywhere.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
-import { resolve } from '../../../../src'
+import { validate } from '../../../../src'
 import extensionsEverywhere from './extensionsEverywhere.yaml'
 
 describe('extensionsEverywhere', () => {
   it('passes', async () => {
-    const result = await resolve(extensionsEverywhere)
+    const result = await validate(extensionsEverywhere)
 
     expect(result.valid).toBe(true)
     expect(result.version).toBe('3.0')

--- a/packages/openapi-parser/tests/openapi3-examples/3.0/pass/externalPathItemRef.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.0/pass/externalPathItemRef.test.ts
@@ -1,7 +1,7 @@
 import path from 'node:path'
 import { describe, expect, it } from 'vitest'
 
-import { loadFiles, resolve } from '../../../../src'
+import { loadFiles, validate } from '../../../../src'
 
 const EXAMPLE_FILE = path.join(
   new URL(import.meta.url).pathname,
@@ -12,7 +12,7 @@ describe('externalPathItemRef', () => {
   it('passes', async () => {
     const filesystem = loadFiles(EXAMPLE_FILE)
 
-    const result = resolve(filesystem)
+    const result = validate(filesystem)
 
     // TODO: Better expectation
     // expect(result.valid).toBe(true)

--- a/packages/openapi-parser/tests/openapi3-examples/3.0/pass/fiendish/ref-encoding2.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.0/pass/fiendish/ref-encoding2.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
-import { resolve } from '../../../../../src'
+import { validate } from '../../../../../src'
 import refEncoding2 from './ref-encoding2.yaml'
 
 describe('ref-encoding2', () => {
   it('passes', async () => {
-    const result = await resolve(refEncoding2)
+    const result = await validate(refEncoding2)
 
     expect(result.errors).toStrictEqual([])
     expect(result.valid).toBe(true)

--- a/packages/openapi-parser/tests/openapi3-examples/3.0/pass/fiendish/ref-encoding3.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.0/pass/fiendish/ref-encoding3.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
-import { resolve } from '../../../../../src'
+import { validate } from '../../../../../src'
 import refEncoding3 from './ref-encoding3.yaml'
 
 describe('ref-encoding3', () => {
   it('passes', async () => {
-    const result = await resolve(refEncoding3)
+    const result = await validate(refEncoding3)
 
     expect(result.errors).toStrictEqual([])
     expect(result.valid).toBe(true)

--- a/packages/openapi-parser/tests/openapi3-examples/3.0/pass/hello.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.0/pass/hello.test.ts
@@ -1,13 +1,13 @@
 import { describe, expect, it } from 'vitest'
 
-import { resolve } from '../../../../src'
+import { validate } from '../../../../src'
 import hello from './hello.yaml'
 
 describe('hello', () => {
   it('passes', async () => {
-    const result = await resolve(hello)
+    const result = await validate(hello)
 
-    expect(result.valid).toBe(true)
+    expect(result.errors?.length).toBe(0)
     expect(result.version).toBe('3.0')
   })
 })

--- a/packages/openapi-parser/tests/openapi3-examples/3.0/pass/minimal.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.0/pass/minimal.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
-import { resolve } from '../../../../src'
+import { validate } from '../../../../src'
 import minimal from './minimal.yaml'
 
 describe('minimal', () => {
   it('passes', async () => {
-    const result = await resolve(minimal)
+    const result = await validate(minimal)
 
     expect(result.valid).toBe(true)
     expect(result.version).toBe('3.0')

--- a/packages/openapi-parser/tests/openapi3-examples/3.0/pass/nonBearerHttpSec.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.0/pass/nonBearerHttpSec.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
-import { resolve } from '../../../../src'
+import { validate } from '../../../../src'
 import nonBearerHttpSec from './nonBearerHttpSec.yaml'
 
 describe('nonBearerHttpSec', () => {
   it('passes', async () => {
-    const result = await resolve(nonBearerHttpSec)
+    const result = await validate(nonBearerHttpSec)
 
     expect(result.valid).toBe(true)
     expect(result.version).toBe('3.0')

--- a/packages/openapi-parser/tests/openapi3-examples/3.0/pass/openapi.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.0/pass/openapi.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
-import { resolve } from '../../../../src'
+import { validate } from '../../../../src'
 import openapi from './openapi.yaml'
 
 describe('openapi', () => {
   it('passes', async () => {
-    const result = await resolve(openapi)
+    const result = await validate(openapi)
 
     expect(result.valid).toBe(true)
     expect(result.version).toBe('3.0')

--- a/packages/openapi-parser/tests/openapi3-examples/3.0/pass/server_enum_empty.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.0/pass/server_enum_empty.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
-import { resolve } from '../../../../src'
+import { validate } from '../../../../src'
 import server_enum_empty from './server_enum_empty.yaml'
 
 describe.todo('server_enum_empty', () => {
   it('passes', async () => {
-    const result = await resolve(server_enum_empty)
+    const result = await validate(server_enum_empty)
 
     expect(result.valid).toBe(true)
     expect(result.version).toBe('3.0')

--- a/packages/openapi-parser/tests/openapi3-examples/3.0/pass/server_enum_unknown.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.0/pass/server_enum_unknown.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
-import { resolve } from '../../../../src'
+import { validate } from '../../../../src'
 import server_enum_unknown from './server_enum_unknown.yaml'
 
 describe.todo('server_enum_unknown', () => {
   it('passes', async () => {
-    const result = await resolve(server_enum_unknown)
+    const result = await validate(server_enum_unknown)
 
     expect(result.valid).toBe(false)
     expect(result.errors?.length).toBe(1)

--- a/packages/openapi-parser/tests/openapi3-examples/3.1/fail/no_containers.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.1/fail/no_containers.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
-import { resolve } from '../../../../src'
+import { validate } from '../../../../src'
 import no_containers from './no_containers.yaml'
 
 describe('no_containers', () => {
   it('returns an error', async () => {
-    const result = await resolve(no_containers)
+    const result = await validate(no_containers)
 
     // TODO: Fix the expected error message should mention 'paths'
     expect(result.errors?.[0]?.message).toBe(

--- a/packages/openapi-parser/tests/openapi3-examples/3.1/fail/server_enum_empty.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.1/fail/server_enum_empty.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
-import { resolve } from '../../../../src'
+import { validate } from '../../../../src'
 import server_enum_empty from './server_enum_empty.yaml'
 
 describe('server_enum_empty', () => {
   it('returns an error', async () => {
-    const result = await resolve(server_enum_empty)
+    const result = await validate(server_enum_empty)
 
     // TODO: The error should return something related to the empty enum
     expect(result.errors?.[0]?.message).toBe(

--- a/packages/openapi-parser/tests/openapi3-examples/3.1/fail/server_enum_unknown.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.1/fail/server_enum_unknown.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
-import { resolve } from '../../../../src'
+import { validate } from '../../../../src'
 import server_enum_unknown from './server_enum_unknown.yaml'
 
 describe('server_enum_unknown', () => {
   it('returns an error', async () => {
-    const result = await resolve(server_enum_unknown)
+    const result = await validate(server_enum_unknown)
 
     // TODO: The message should return something related to the unknown enum value
     expect(result.errors?.[0]?.message).toBe(

--- a/packages/openapi-parser/tests/openapi3-examples/3.1/fail/unknown_container.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.1/fail/unknown_container.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
-import { resolve } from '../../../../src'
+import { validate } from '../../../../src'
 import unknown_container from './unknown_container.yaml'
 
 describe('unknown_container', () => {
   it('returns an error', async () => {
-    const result = await resolve(unknown_container)
+    const result = await validate(unknown_container)
 
     // TODO: The message should complain about the unknown container
     expect(result.errors?.[0]?.message).toBe(

--- a/packages/openapi-parser/tests/openapi3-examples/3.1/pass/comp_pathitems.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.1/pass/comp_pathitems.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
-import { resolve } from '../../../../src'
+import { validate } from '../../../../src'
 import comp_pathitems from './comp_pathitems.yaml'
 
 describe('comp_pathitems', () => {
   it('passes', async () => {
-    const result = await resolve(comp_pathitems)
+    const result = await validate(comp_pathitems)
     expect(result.valid).toBe(true)
     expect(result.errors).toStrictEqual([])
     expect(result.version).toBe('3.1')

--- a/packages/openapi-parser/tests/openapi3-examples/3.1/pass/info_summary.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.1/pass/info_summary.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
-import { resolve } from '../../../../src'
+import { validate } from '../../../../src'
 import info_summary from './info_summary.yaml'
 
 describe('info_summary', () => {
   it('passes', async () => {
-    const result = await resolve(info_summary)
+    const result = await validate(info_summary)
     expect(result.valid).toBe(true)
     expect(result.errors).toStrictEqual([])
     expect(result.version).toBe('3.1')

--- a/packages/openapi-parser/tests/openapi3-examples/3.1/pass/license_identifier.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.1/pass/license_identifier.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
-import { resolve } from '../../../../src'
+import { validate } from '../../../../src'
 import license_identifier from './license_identifier.yaml'
 
 describe('license_identifier', () => {
   it('passes', async () => {
-    const result = await resolve(license_identifier)
+    const result = await validate(license_identifier)
     expect(result.valid).toBe(true)
     expect(result.errors).toStrictEqual([])
     expect(result.version).toBe('3.1')

--- a/packages/openapi-parser/tests/openapi3-examples/3.1/pass/mega.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.1/pass/mega.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
-import { resolve } from '../../../../src'
+import { validate } from '../../../../src'
 import mega from './mega.yaml'
 
 describe('mega', () => {
   it('passes', async () => {
-    const result = await resolve(mega)
+    const result = await validate(mega)
     expect(result.valid).toBe(true)
     expect(result.errors).toStrictEqual([])
     expect(result.version).toBe('3.1')

--- a/packages/openapi-parser/tests/openapi3-examples/3.1/pass/minimal_comp.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.1/pass/minimal_comp.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
-import { resolve } from '../../../../src'
+import { validate } from '../../../../src'
 import minimal_comp from './minimal_comp.yaml'
 
 describe('minimal_comp', () => {
   it('passes', async () => {
-    const result = await resolve(minimal_comp)
+    const result = await validate(minimal_comp)
     expect(result.valid).toBe(true)
     expect(result.errors).toStrictEqual([])
     expect(result.version).toBe('3.1')

--- a/packages/openapi-parser/tests/openapi3-examples/3.1/pass/minimal_hooks.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.1/pass/minimal_hooks.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
-import { resolve } from '../../../../src'
+import { validate } from '../../../../src'
 import minimal_hooks from './minimal_hooks.yaml'
 
 describe('minimal_hooks', () => {
   it('passes', async () => {
-    const result = await resolve(minimal_hooks)
+    const result = await validate(minimal_hooks)
     expect(result.valid).toBe(true)
     expect(result.errors).toStrictEqual([])
     expect(result.version).toBe('3.1')

--- a/packages/openapi-parser/tests/openapi3-examples/3.1/pass/minimal_paths.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.1/pass/minimal_paths.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
-import { resolve } from '../../../../src'
+import { validate } from '../../../../src'
 import minimal_paths from './minimal_paths.yaml'
 
 describe('minimal_paths', () => {
   it('passes', async () => {
-    const result = await resolve(minimal_paths)
+    const result = await validate(minimal_paths)
     expect(result.valid).toBe(true)
     expect(result.errors).toStrictEqual([])
     expect(result.version).toBe('3.1')

--- a/packages/openapi-parser/tests/openapi3-examples/3.1/pass/path_no_response.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.1/pass/path_no_response.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
-import { resolve } from '../../../../src'
+import { validate } from '../../../../src'
 import path_no_response from './path_no_response.yaml'
 
 describe('path_no_response', () => {
   it('passes', async () => {
-    const result = await resolve(path_no_response)
+    const result = await validate(path_no_response)
     expect(result.valid).toBe(true)
     expect(result.errors).toStrictEqual([])
     expect(result.version).toBe('3.1')

--- a/packages/openapi-parser/tests/openapi3-examples/3.1/pass/path_var_empty_pathitem.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.1/pass/path_var_empty_pathitem.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
-import { resolve } from '../../../../src'
+import { validate } from '../../../../src'
 import path_var_empty_pathitem from './path_var_empty_pathitem.yaml'
 
 describe('path_var_empty_pathitem', () => {
   it('passes', async () => {
-    const result = await resolve(path_var_empty_pathitem)
+    const result = await validate(path_var_empty_pathitem)
     expect(result.valid).toBe(true)
     expect(result.errors).toStrictEqual([])
     expect(result.version).toBe('3.1')

--- a/packages/openapi-parser/tests/openapi3-examples/3.1/pass/schema.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.1/pass/schema.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
-import { resolve } from '../../../../src'
+import { validate } from '../../../../src'
 import schema from './schema.yaml'
 
 describe('schema', () => {
   it('passes', async () => {
-    const result = await resolve(schema)
+    const result = await validate(schema)
     expect(result.valid).toBe(true)
     expect(result.errors).toStrictEqual([])
     expect(result.version).toBe('3.1')


### PR DESCRIPTION
Currently, we have the `resolve()` utility, which is actually validating *and* resolving all references. I think that was a mistake.

This PR removes validation from the `resolve` utility.

I’ll probably add a few more changes to it, to align the output of all the utilities more.