### PR TITLE
fix: Unable to load files in Node

### DIFF
--- a/.changeset/tasty-buttons-develop.md
+++ b/.changeset/tasty-buttons-develop.md
@@ -1,0 +1,5 @@
+---
+"@scalar/openapi-parser": patch
+---
+
+fix: existsSync is not a function

--- a/packages/openapi-parser/vite.config.ts
+++ b/packages/openapi-parser/vite.config.ts
@@ -11,6 +11,9 @@ export default defineConfig({
       name: '@scalar/openapi-parser',
       formats: ['es'],
     },
+    rollupOptions: {
+      external: ['node:fs', 'node:path'],
+    },
   },
   test: {
     coverage: {


### PR DESCRIPTION
**Problem**
Currently, when using `loadFiles()`, an error is raised

```ts
loadFiles(path.resolve('/path/to/openapi.yaml'))
```
causes the following error:

```
Yt.existsSync is not a function
```

**Explanation**

`*.existsSync` is called here:  https://github.com/scalar/openapi-parser/blob/main/packages/openapi-parser/src/utils/loadFiles.ts#L16

Checking through the bundled module, it looks like `Yt` is just defined as `Yt={}`.


**Solution**
This PR adds `node:fs` and `node:path` to `rollupOptions.external` in `vite.config.ts` which results in successfully reading specs from disk.