### PR TITLE
feat: limit number of http requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ import {
 
 // Load a file and all referenced files
 const filesystem = await load('./openapi.yaml', {
-  plugins: [readFilesPlugin, fetchUrlsPlugin],
+  plugins: [readFilesPlugin(), fetchUrlsPlugin()],
 })
 
 // Instead of just passing a single specification, pass the whole “filesystem”

--- a/demo/package.json
+++ b/demo/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@scalar/openapi-parser": "workspace:*",
+    "@vueuse/core": "^10.9.0",
     "vue": "^3.4.27"
   },
   "devDependencies": {

--- a/demo/src/App.vue
+++ b/demo/src/App.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { fetchUrlsPlugin, openapi } from '@scalar/openapi-parser'
+import { watchDebounced } from '@vueuse/core'
 import { onMounted, ref, watch } from 'vue'
 
 const value = ref(
@@ -43,7 +44,7 @@ watch(value, async (newValue) => {
   window.localStorage.setItem('value', newValue)
 })
 
-watch(
+watchDebounced(
   value,
   async (newValue) => {
     result.value = (
@@ -56,6 +57,8 @@ watch(
     )?.schema
   },
   {
+    debounce: 500,
+    maxWait: 1000,
     immediate: true,
   },
 )

--- a/demo/src/App.vue
+++ b/demo/src/App.vue
@@ -50,7 +50,7 @@ watchDebounced(
     result.value = (
       await openapi()
         .load(newValue, {
-          plugins: [fetchUrlsPlugin],
+          plugins: [fetchUrlsPlugin()],
         })
         .dereference()
         .get()

--- a/packages/openapi-parser/src/pipeline.test.ts
+++ b/packages/openapi-parser/src/pipeline.test.ts
@@ -55,7 +55,7 @@ describe('pipeline', () => {
   it('load file', async () => {
     const result = await openapi()
       .load(EXAMPLE_FILE, {
-        plugins: [readFilesPlugin],
+        plugins: [readFilesPlugin()],
       })
       .get()
 
@@ -65,7 +65,7 @@ describe('pipeline', () => {
   it('files', async () => {
     const filesystem = await openapi()
       .load(EXAMPLE_FILE, {
-        plugins: [readFilesPlugin],
+        plugins: [readFilesPlugin()],
       })
       .files()
 

--- a/packages/openapi-parser/src/utils/load/load.test.ts
+++ b/packages/openapi-parser/src/utils/load/load.test.ts
@@ -19,7 +19,7 @@ describe('load', async () => {
         paths: {},
       },
       {
-        plugins: [readFilesPlugin, fetchUrlsPlugin],
+        plugins: [readFilesPlugin(), fetchUrlsPlugin()],
       },
     )
 
@@ -44,7 +44,7 @@ describe('load', async () => {
         paths: {},
       }),
       {
-        plugins: [readFilesPlugin, fetchUrlsPlugin],
+        plugins: [readFilesPlugin(), fetchUrlsPlugin()],
       },
     )
 
@@ -69,7 +69,7 @@ describe('load', async () => {
         paths: {},
       }),
       {
-        plugins: [readFilesPlugin, fetchUrlsPlugin],
+        plugins: [readFilesPlugin(), fetchUrlsPlugin()],
       },
     )
 
@@ -90,7 +90,7 @@ describe('load', async () => {
     )
 
     const filesystem = await load(EXAMPLE_FILE, {
-      plugins: [readFilesPlugin, fetchUrlsPlugin],
+      plugins: [readFilesPlugin(), fetchUrlsPlugin()],
     })
 
     expect(getEntrypoint(filesystem).specification).toMatchObject({
@@ -110,7 +110,7 @@ describe('load', async () => {
     )
 
     const filesystem = await load(EXAMPLE_FILE, {
-      plugins: [readFilesPlugin],
+      plugins: [readFilesPlugin()],
     })
 
     // filenames
@@ -151,7 +151,7 @@ describe('load', async () => {
     })
 
     const filesystem = await load('https://example.com/openapi.yaml', {
-      plugins: [readFilesPlugin, fetchUrlsPlugin],
+      plugins: [readFilesPlugin(), fetchUrlsPlugin()],
     })
 
     expect(getEntrypoint(filesystem).specification).toMatchObject({
@@ -194,7 +194,7 @@ describe('load', async () => {
         },
       },
       {
-        plugins: [readFilesPlugin, fetchUrlsPlugin],
+        plugins: [readFilesPlugin(), fetchUrlsPlugin()],
       },
     )
 
@@ -251,7 +251,7 @@ describe('load', async () => {
     }
 
     const filesystem = await load('https://example.com/openapi.yaml', {
-      plugins: [readFilesPlugin, fetchUrlsPlugin],
+      plugins: [readFilesPlugin(), fetchUrlsPlugin()],
     })
 
     expect(filesystem[0].specification).toMatchObject({
@@ -319,7 +319,7 @@ describe('load', async () => {
         },
       }),
       {
-        plugins: [readFilesPlugin, fetchUrlsPlugin],
+        plugins: [readFilesPlugin(), fetchUrlsPlugin()],
       },
     )
 

--- a/packages/openapi-parser/src/utils/load/load.ts
+++ b/packages/openapi-parser/src/utils/load/load.ts
@@ -17,8 +17,17 @@ export async function load(
   options?: {
     plugins?: LoadPlugin[]
     filename?: string
+    filesystem?: Filesystem
   },
 ) {
+  // Don’t load a reference twice, check the filesystem before fetching something
+  if (
+    options?.filesystem &&
+    options?.filesystem.find((entry) => entry.filename === value)
+  ) {
+    return options.filesystem
+  }
+
   // Check whether the value is an URL or file path
   const plugin = options?.plugins?.find((plugin) => plugin.check(value))
   const content = normalize(plugin ? await plugin.get(value) : value)
@@ -36,7 +45,7 @@ export async function load(
 
   // Load other external references
   for (const reference of listOfReferences) {
-    // find first plugin
+    // Find a matching plugin
     const plugin = options?.plugins?.find((plugin) => plugin.check(reference))
 
     const target =
@@ -58,62 +67,14 @@ export async function load(
 
     filesystem = [
       ...filesystem,
-      ...referencedFiles
-        .filter(
-          (entry) =>
-            !filesystem.find((file) => file.filename === entry.filename),
-        )
-        .map((file) => {
-          return {
-            ...file,
-            isEntrypoint: false,
-          }
-        }),
+      ...referencedFiles.map((file) => {
+        return {
+          ...file,
+          isEntrypoint: false,
+        }
+      }),
     ]
   }
 
   return filesystem
-
-  //   // Create a temporary filesystem
-  //   const rootDir = plugin.getDir ? plugin.getDir(value) : value
-
-  //   const rootFilename = plugin.getFilename ? plugin.getFilename(value) : value
-
-  //   filesystem = makeFilesystem(content, {
-  //     filename: options.filename ?? rootFilename,
-  //     dir: rootDir,
-  //   })
-
-  //   // No other references
-  //   if (listOfReferences.length === 0) {
-  //     return filesystem
-  //   }
-
-  //   // Load other external references
-  //   for (const reference of listOfReferences) {
-  //     const target =
-  //       plugin.check(reference) && plugin.resolvePath
-  //         ? plugin.resolvePath(value, reference)
-  //         : reference
-
-  //     const referencedFiles = await load(target, {
-  //       ...options,
-  //       // Make the filename the exact same value as the $ref
-  //       // TODO: This leads to problems, if there are multiple references with the same file name but in different folders
-  //       filename: reference,
-  //     })
-
-  //     filesystem = [
-  //       ...filesystem,
-  //       ...referencedFiles.map((file) => {
-  //         return {
-  //           ...file,
-  //           isEntrypoint: false,
-  //         }
-  //       }),
-  //     ]
-  //   }
-  // }
-
-  // return filesystem
 }

--- a/packages/openapi-parser/src/utils/load/load.ts
+++ b/packages/openapi-parser/src/utils/load/load.ts
@@ -31,6 +31,12 @@ export async function load(
   // Check whether the value is an URL or file path
   const plugin = options?.plugins?.find((plugin) => plugin.check(value))
   const content = normalize(plugin ? await plugin.get(value) : value)
+
+  // No content
+  if (content === undefined) {
+    return []
+  }
+
   let filesystem = makeFilesystem(content, {
     filename: options?.filename ?? null,
   })

--- a/packages/openapi-parser/src/utils/load/plugins/fetchUrlsPlugin.test.ts
+++ b/packages/openapi-parser/src/utils/load/plugins/fetchUrlsPlugin.test.ts
@@ -5,23 +5,23 @@ import { fetchUrlsPlugin } from './fetchUrlsPlugin'
 describe('fetchUrlsPlugin', async () => {
   it('returns true for an url', async () => {
     expect(
-      fetchUrlsPlugin.check('http://example.com/specification/openapi.yaml'),
+      fetchUrlsPlugin().check('http://example.com/specification/openapi.yaml'),
     ).toBe(true)
   })
 
   it('returns false for a filename', async () => {
-    expect(fetchUrlsPlugin.check('openapi.yaml')).toBe(false)
+    expect(fetchUrlsPlugin().check('openapi.yaml')).toBe(false)
   })
 
   it('returns false for a path', async () => {
-    expect(fetchUrlsPlugin.check('specification/openapi.yaml')).toBe(false)
+    expect(fetchUrlsPlugin().check('specification/openapi.yaml')).toBe(false)
   })
 
   it('returns false for an object', async () => {
-    expect(fetchUrlsPlugin.check({})).toBe(false)
+    expect(fetchUrlsPlugin().check({})).toBe(false)
   })
 
   it('returns false for undefinded', async () => {
-    expect(fetchUrlsPlugin.check()).toBe(false)
+    expect(fetchUrlsPlugin().check()).toBe(false)
   })
 })

--- a/packages/openapi-parser/src/utils/load/plugins/fetchUrlsPlugin.ts
+++ b/packages/openapi-parser/src/utils/load/plugins/fetchUrlsPlugin.ts
@@ -1,26 +1,28 @@
 import { LoadPlugin } from '../load'
 
-export const fetchUrlsPlugin: LoadPlugin = {
-  check(value?: any) {
-    // Not a string
-    if (typeof value !== 'string') {
-      return false
-    }
+export const fetchUrlsPlugin: () => LoadPlugin = () => {
+  return {
+    check(value?: any) {
+      // Not a string
+      if (typeof value !== 'string') {
+        return false
+      }
 
-    // Not http/https
-    if (!value.startsWith('http://') && !value.startsWith('https://')) {
-      return false
-    }
+      // Not http/https
+      if (!value.startsWith('http://') && !value.startsWith('https://')) {
+        return false
+      }
 
-    return true
-  },
-  async get(value?: any) {
-    try {
-      const response = await fetch(value)
+      return true
+    },
+    async get(value?: any) {
+      try {
+        const response = await fetch(value)
 
-      return await response.text()
-    } catch (error) {
-      console.error('[fetchUrlsPlugin]', error)
-    }
-  },
+        return await response.text()
+      } catch (error) {
+        console.error('[fetchUrlsPlugin]', error.message)
+      }
+    },
+  }
 }

--- a/packages/openapi-parser/src/utils/load/plugins/fetchUrlsPlugin.ts
+++ b/packages/openapi-parser/src/utils/load/plugins/fetchUrlsPlugin.ts
@@ -1,7 +1,7 @@
 import { LoadPlugin } from '../load'
 
 export const fetchUrlsPluginDefaultConfiguration = {
-  limit: 10,
+  limit: 20,
 }
 
 export const fetchUrlsPlugin: (customConfiguration?: {

--- a/packages/openapi-parser/src/utils/load/plugins/readFilesPlugin.test.ts
+++ b/packages/openapi-parser/src/utils/load/plugins/readFilesPlugin.test.ts
@@ -4,24 +4,24 @@ import { readFilesPlugin } from './readFilesPlugin'
 
 describe('readFilesPlugin', async () => {
   it('returns true for a filename', async () => {
-    expect(readFilesPlugin.check('openapi.yaml')).toBe(true)
+    expect(readFilesPlugin().check('openapi.yaml')).toBe(true)
   })
 
   it('returns true for a path', async () => {
-    expect(readFilesPlugin.check('../specification/openapi.yaml')).toBe(true)
+    expect(readFilesPlugin().check('../specification/openapi.yaml')).toBe(true)
   })
 
   it('returns false for an object', async () => {
-    expect(readFilesPlugin.check({})).toBe(false)
+    expect(readFilesPlugin().check({})).toBe(false)
   })
 
   it('returns false for undefinded', async () => {
-    expect(readFilesPlugin.check()).toBe(false)
+    expect(readFilesPlugin().check()).toBe(false)
   })
 
   it('returns false for an url', async () => {
     expect(
-      readFilesPlugin.check('http://example.com/specification/openapi.yaml'),
+      readFilesPlugin().check('http://example.com/specification/openapi.yaml'),
     ).toBe(false)
   })
 })

--- a/packages/openapi-parser/src/utils/load/plugins/readFilesPlugin.ts
+++ b/packages/openapi-parser/src/utils/load/plugins/readFilesPlugin.ts
@@ -6,54 +6,56 @@ import { isJson } from '../../isJson'
 import { isYaml } from '../../isYaml'
 import { LoadPlugin } from '../load'
 
-export const readFilesPlugin: LoadPlugin = {
-  check(value?: any) {
-    // Not a string
-    if (typeof value !== 'string') {
-      return false
-    }
+export const readFilesPlugin: () => LoadPlugin = () => {
+  return {
+    check(value?: any) {
+      // Not a string
+      if (typeof value !== 'string') {
+        return false
+      }
 
-    // URL
-    if (value.startsWith('http://') || value.startsWith('https://')) {
-      return false
-    }
+      // URL
+      if (value.startsWith('http://') || value.startsWith('https://')) {
+        return false
+      }
 
-    // Line breaks
-    if (value.includes('\n')) {
-      return false
-    }
+      // Line breaks
+      if (value.includes('\n')) {
+        return false
+      }
 
-    // JSON
-    if (isJson(value)) {
-      return false
-    }
+      // JSON
+      if (isJson(value)) {
+        return false
+      }
 
-    // YAML (run through YAML.parse)
-    if (isYaml(value)) {
-      return false
-    }
+      // YAML (run through YAML.parse)
+      if (isYaml(value)) {
+        return false
+      }
 
-    return true
-  },
-  async get(value?: any) {
-    if (!fs.existsSync(value)) {
-      throw new Error(ERRORS.FILE_DOES_NOT_EXIST.replace('%s', value))
-    }
+      return true
+    },
+    async get(value?: any) {
+      if (!fs.existsSync(value)) {
+        throw new Error(ERRORS.FILE_DOES_NOT_EXIST.replace('%s', value))
+      }
 
-    try {
-      return fs.readFileSync(value, 'utf-8')
-    } catch (error) {
-      console.error('[readFilesPlugin]', error)
-    }
-  },
-  resolvePath(value: any, reference: string) {
-    const dir = dirname(value)
-    return join(dir, reference)
-  },
-  getDir(value: any) {
-    return dirname(value)
-  },
-  getFilename(value: any) {
-    return value.split('/').pop()
-  },
+      try {
+        return fs.readFileSync(value, 'utf-8')
+      } catch (error) {
+        console.error('[readFilesPlugin]', error)
+      }
+    },
+    resolvePath(value: any, reference: string) {
+      const dir = dirname(value)
+      return join(dir, reference)
+    },
+    getDir(value: any) {
+      return dirname(value)
+    },
+    getFilename(value: any) {
+      return value.split('/').pop()
+    },
+  }
 }

--- a/packages/openapi-parser/src/utils/resolveReferences.test.ts
+++ b/packages/openapi-parser/src/utils/resolveReferences.test.ts
@@ -642,7 +642,7 @@ describe('resolveReferences', () => {
 
   it('resolves from filesystem', async () => {
     const filesystem = await load(EXAMPLE_FILE, {
-      plugins: [readFilesPlugin],
+      plugins: [readFilesPlugin()],
     })
 
     const { schema } = resolveReferences(filesystem)

--- a/packages/openapi-parser/tests/openapi3-examples/3.0/pass/externalPathItemRef.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.0/pass/externalPathItemRef.test.ts
@@ -11,7 +11,7 @@ const EXAMPLE_FILE = path.join(
 describe('externalPathItemRef', () => {
   it('passes', async () => {
     const filesystem = await load(EXAMPLE_FILE, {
-      plugins: [readFilesPlugin],
+      plugins: [readFilesPlugin()],
     })
 
     const result = await validate(filesystem)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       '@scalar/openapi-parser':
         specifier: workspace:*
         version: link:../packages/openapi-parser
+      '@vueuse/core':
+        specifier: ^10.9.0
+        version: 10.9.0(vue@3.4.27)
       vue:
         specifier: ^3.4.27
         version: 3.4.27(typescript@5.4.5)
@@ -1204,6 +1207,10 @@ packages:
     resolution: {integrity: sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==}
     dev: true
 
+  /@types/web-bluetooth@0.0.20:
+    resolution: {integrity: sha512-g9gZnnXVq7gM7v3tJCWV/qw7w+KeOlSHAhgF9RytFyifW6AF61hdT2ucrYhPq9hLs5JIryeupHV3qGk95dH9ow==}
+    dev: false
+
   /@vitejs/plugin-vue@5.0.4(vite@5.2.11)(vue@3.4.27):
     resolution: {integrity: sha512-WS3hevEszI6CEVEx28F8RjTX97k3KsrcY6kvTg7+Whm5y3oYvcqzVeGCU3hxSAn4uY2CLCkeokkGKpoctccilQ==}
     engines: {node: ^18.0.0 || >=20.0.0}
@@ -1393,6 +1400,31 @@ packages:
 
   /@vue/shared@3.4.27:
     resolution: {integrity: sha512-DL3NmY2OFlqmYYrzp39yi3LDkKxa5vZVwxWdQ3rG0ekuWscHraeIbnI8t+aZK7qhYqEqWKTUdijadunb9pnrgA==}
+
+  /@vueuse/core@10.9.0(vue@3.4.27):
+    resolution: {integrity: sha512-/1vjTol8SXnx6xewDEKfS0Ra//ncg4Hb0DaZiwKf7drgfMsKFExQ+FnnENcN6efPen+1kIzhLQoGSy0eDUVOMg==}
+    dependencies:
+      '@types/web-bluetooth': 0.0.20
+      '@vueuse/metadata': 10.9.0
+      '@vueuse/shared': 10.9.0(vue@3.4.27)
+      vue-demi: 0.14.7(vue@3.4.27)
+    transitivePeerDependencies:
+      - '@vue/composition-api'
+      - vue
+    dev: false
+
+  /@vueuse/metadata@10.9.0:
+    resolution: {integrity: sha512-iddNbg3yZM0X7qFY2sAotomgdHK7YJ6sKUvQqbvwnf7TmaVPxS4EJydcNsVejNdS8iWCtDk+fYXr7E32nyTnGA==}
+    dev: false
+
+  /@vueuse/shared@10.9.0(vue@3.4.27):
+    resolution: {integrity: sha512-Uud2IWncmAfJvRaFYzv5OHDli+FbOzxiVEQdLCKQKLyhz94PIyFC3CHcH7EDMwIn8NPtD06+PNbC/PiO0LGLtw==}
+    dependencies:
+      vue-demi: 0.14.7(vue@3.4.27)
+    transitivePeerDependencies:
+      - '@vue/composition-api'
+      - vue
+    dev: false
 
   /acorn-walk@8.3.2:
     resolution: {integrity: sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A==}
@@ -4001,6 +4033,21 @@ packages:
       - supports-color
       - terser
     dev: true
+
+  /vue-demi@0.14.7(vue@3.4.27):
+    resolution: {integrity: sha512-EOG8KXDQNwkJILkx/gPcoL/7vH+hORoBaKgGe+6W7VFMvCYJfmF2dGbvgDroVnI8LU7/kTu8mbjRZGBU1z9NTA==}
+    engines: {node: '>=12'}
+    hasBin: true
+    requiresBuild: true
+    peerDependencies:
+      '@vue/composition-api': ^1.0.0-rc.1
+      vue: ^3.0.0-0 || ^2.6.0
+    peerDependenciesMeta:
+      '@vue/composition-api':
+        optional: true
+    dependencies:
+      vue: 3.4.27(typescript@5.4.5)
+    dev: false
 
   /vue-template-compiler@2.7.16:
     resolution: {integrity: sha512-AYbUWAJHLGGQM7+cNTELw+KsOG9nl2CnSv467WobS5Cv9uk3wFcnr1Etsz2sEIHEZvw1U+o9mRlEO6QbZvUPGQ==}


### PR DESCRIPTION
With this PR we’re dealing better with HTTP errors and limit the number of requests to 20 (configurable).

Plugins became functions, so it’s easier to pass a configuration.