### PR TITLE
feat: intercept requests

### DIFF
--- a/.changeset/plenty-cooks-push.md
+++ b/.changeset/plenty-cooks-push.md
@@ -1,0 +1,5 @@
+---
+'@scalar/openapi-parser': patch
+---
+
+feat: intercept fetch requests

--- a/packages/openapi-parser/src/utils/load/plugins/fetchUrlsPlugin.test.ts
+++ b/packages/openapi-parser/src/utils/load/plugins/fetchUrlsPlugin.test.ts
@@ -24,4 +24,42 @@ describe('fetchUrlsPlugin', async () => {
   it('returns false for undefinded', async () => {
     expect(fetchUrlsPlugin().check()).toBe(false)
   })
+
+  it('fetches the URL', async () => {
+    // @ts-expect-error only partially patched
+    global.fetch = async (url: string) => ({
+      text: async () => {
+        if (url === 'http://example.com/specification/openapi.yaml') {
+          return 'OK'
+        }
+
+        throw new Error('Not found')
+      },
+    })
+
+    expect(
+      await fetchUrlsPlugin().get(
+        'http://example.com/specification/openapi.yaml',
+      ),
+    ).toBe('OK')
+  })
+
+  it('rewrites the URL', async () => {
+    // @ts-expect-error only partially patched
+    global.fetch = async (url: string) => ({
+      text: async () => {
+        if (url === 'http://foobar.com/specification/openapi.yaml') {
+          return 'OK'
+        }
+
+        throw new Error('Not found')
+      },
+    })
+
+    expect(
+      await fetchUrlsPlugin({
+        fetch: (url) => fetch(url.replace('example', 'foobar')),
+      }).get('http://foobar.com/specification/openapi.yaml'),
+    ).toBe('OK')
+  })
 })

--- a/packages/openapi-parser/src/utils/load/plugins/fetchUrlsPlugin.ts
+++ b/packages/openapi-parser/src/utils/load/plugins/fetchUrlsPlugin.ts
@@ -5,7 +5,14 @@ export const fetchUrlsPluginDefaultConfiguration = {
 }
 
 export const fetchUrlsPlugin: (customConfiguration?: {
+  /**
+   * Limit the number of requests. Set to `false` to disable the limit.
+   */
   limit?: number | false
+  /**
+   * Fetch function to use instead of the global fetch. Use this to intercept requests.
+   */
+  fetch?: (url: string) => Promise<Response>
 }) => LoadPlugin = (customConfiguration) => {
   // State
   let numberOfRequests = 0
@@ -44,7 +51,10 @@ export const fetchUrlsPlugin: (customConfiguration?: {
 
       try {
         numberOfRequests++
-        const response = await fetch(value)
+
+        const response = await (configuration?.fetch
+          ? configuration.fetch(value)
+          : fetch(value))
 
         return await response.text()
       } catch (error) {


### PR DESCRIPTION
With this PR requests to URLs can be intercepted. This is great to redirect requests to a proxy. :)

```ts
fetchUrlsPlugin({
  fetch: (url) => fetch(url.replace('foo', 'bar')),
})
```