### PR TITLE
chore: improve types

### DIFF
--- a/demo/src/App.vue
+++ b/demo/src/App.vue
@@ -2,7 +2,7 @@
 import { dereference, fetchUrlsPlugin, load } from '@scalar/openapi-parser'
 import { watchDebounced } from '@vueuse/core'
 import { onMounted, ref, watch } from 'vue'
-// @ts-ignore
+// @ts-expect-error Package doesn’t come with types
 import JsonViewer from 'vue-json-viewer'
 
 const value = ref(

--- a/packages/openapi-parser/src/utils/dereference.test.ts
+++ b/packages/openapi-parser/src/utils/dereference.test.ts
@@ -147,7 +147,6 @@ it('resolves a simple reference', async () => {
 
   // Original
   expect(
-    // @ts-ignore
     result.specification.paths['/test'].get.responses['200'].content[
       'application/json'
     ].schema,
@@ -157,7 +156,6 @@ it('resolves a simple reference', async () => {
 
   // Resolved references
   expect(
-    // @ts-ignore
     result.schema.paths['/test'].get.responses['200'].content[
       'application/json'
     ].schema,

--- a/packages/openapi-parser/src/utils/load/load.test.ts
+++ b/packages/openapi-parser/src/utils/load/load.test.ts
@@ -137,18 +137,18 @@ describe('load', async () => {
   })
 
   it('loads url', async () => {
-    // @ts-expect-error only partially patched
-    global.fetch = async () => ({
-      text: async () =>
-        stringify({
-          openapi: '3.1.0',
-          info: {
-            title: 'Hello World',
-            version: '1.0.0',
-          },
-          paths: {},
-        }),
-    })
+    global.fetch = async () =>
+      ({
+        text: async () =>
+          stringify({
+            openapi: '3.1.0',
+            info: {
+              title: 'Hello World',
+              version: '1.0.0',
+            },
+            paths: {},
+          }),
+      }) as Response
 
     const { filesystem } = await load('https://example.com/openapi.yaml', {
       plugins: [readFilesPlugin(), fetchUrlsPlugin()],
@@ -209,12 +209,10 @@ describe('load', async () => {
   })
 
   it('limits the number of requests', async () => {
-    // @ts-expect-error only partially patched
-    global.fetch = async () => {
-      return {
+    global.fetch = async () =>
+      ({
         text: async () => 'FOOBAR',
-      }
-    }
+      }) as unknown as Response
 
     const { filesystem } = await load(
       {
@@ -252,7 +250,6 @@ describe('load', async () => {
   })
 
   it('loads referenced urls', async () => {
-    // @ts-expect-error only partially patched
     global.fetch = async (url: string) => {
       if (url === 'https://example.com/openapi.yaml') {
         return {
@@ -273,7 +270,7 @@ describe('load', async () => {
                 },
               },
             }),
-        }
+        } as Response
       }
 
       if (url === 'https://example.com/foobar.json') {
@@ -289,7 +286,7 @@ describe('load', async () => {
                 },
               },
             }),
-        }
+        } as Response
       }
     }
 
@@ -327,8 +324,7 @@ describe('load', async () => {
   })
 
   it('loads string with url reference', async () => {
-    // @ts-expect-error only partially patched
-    global.fetch = async (url: string) => {
+    global.fetch = async () => {
       return {
         text: async () =>
           JSON.stringify({
@@ -341,7 +337,7 @@ describe('load', async () => {
               },
             },
           }),
-      }
+      } as Response
     }
 
     const { filesystem } = await load(

--- a/packages/openapi-parser/src/utils/load/plugins/fetchUrlsPlugin.test.ts
+++ b/packages/openapi-parser/src/utils/load/plugins/fetchUrlsPlugin.test.ts
@@ -26,16 +26,16 @@ describe('fetchUrlsPlugin', async () => {
   })
 
   it('fetches the URL', async () => {
-    // @ts-expect-error only partially patched
-    global.fetch = async (url: string) => ({
-      text: async () => {
-        if (url === 'http://example.com/specification/openapi.yaml') {
-          return 'OK'
-        }
+    global.fetch = async (url: string) =>
+      ({
+        text: async () => {
+          if (url === 'http://example.com/specification/openapi.yaml') {
+            return 'OK'
+          }
 
-        throw new Error('Not found')
-      },
-    })
+          throw new Error('Not found')
+        },
+      }) as Response
 
     expect(
       await fetchUrlsPlugin().get(
@@ -45,16 +45,16 @@ describe('fetchUrlsPlugin', async () => {
   })
 
   it('rewrites the URL', async () => {
-    // @ts-expect-error only partially patched
-    global.fetch = async (url: string) => ({
-      text: async () => {
-        if (url === 'http://foobar.com/specification/openapi.yaml') {
-          return 'OK'
-        }
+    global.fetch = async (url: string) =>
+      ({
+        text: async () => {
+          if (url === 'http://foobar.com/specification/openapi.yaml') {
+            return 'OK'
+          }
 
-        throw new Error('Not found')
-      },
-    })
+          throw new Error('Not found')
+        },
+      }) as Response
 
     expect(
       await fetchUrlsPlugin({

--- a/packages/openapi-parser/src/utils/resolveReferences.test.ts
+++ b/packages/openapi-parser/src/utils/resolveReferences.test.ts
@@ -375,7 +375,6 @@ describe('resolveReferences', () => {
     const { schema } = resolveReferences(specification)
 
     // Assertion
-    // @ts-ignore
     expect(schema.swagger).toBe('2.0')
     expect(
       schema.paths['/foobar'].post.responses[200].schema.properties.dictionaries
@@ -519,7 +518,6 @@ describe('resolveReferences', () => {
     const { schema } = resolveReferences(filesystem)
 
     expect(
-      // @ts-ignore
       schema.paths['/foobar'].post.requestBody.content['application/json']
         .schema.example,
     ).toBe('foobar')
@@ -572,7 +570,6 @@ describe('resolveReferences', () => {
 
     const { schema } = resolveReferences(filesystem)
     expect(
-      // @ts-ignore
       schema.paths['/foobar'].post.requestBody.content['application/json']
         .schema.example,
     ).toBe('foobar')
@@ -634,7 +631,6 @@ describe('resolveReferences', () => {
 
     const { schema } = resolveReferences(filesystem)
     expect(
-      // @ts-ignore
       schema.paths['/foobar'].post.requestBody.content['application/json']
         .schema.example,
     ).toBe('foobar')

--- a/packages/openapi-parser/src/utils/upgradeFromThreeToThreeOne.ts
+++ b/packages/openapi-parser/src/utils/upgradeFromThreeToThreeOne.ts
@@ -77,6 +77,15 @@ export function upgradeFromThreeToThreeOne(specification: AnyObject) {
     return schema
   })
 
+  // Uploading a binary file in a POST request
+  specification = traverse(specification, (schema) => {
+    if (schema.type === 'string' && schema.format === 'binary') {
+      return undefined
+    }
+
+    return schema
+  })
+
   // Uploading an image with base64 encoding
   specification = traverse(specification, (schema) => {
     if (schema.type === 'string' && schema.format === 'base64') {

--- a/packages/openapi-parser/src/utils/upgradeFromThreeToThreeOne.ts
+++ b/packages/openapi-parser/src/utils/upgradeFromThreeToThreeOne.ts
@@ -59,29 +59,19 @@ export function upgradeFromThreeToThreeOne(specification: AnyObject) {
   // Multipart file uploads with a binary file
   specification = traverse(specification, (schema) => {
     if (schema.type === 'object' && schema.properties !== undefined) {
-      for (const [_, value] of Object.entries(schema.properties)) {
+      // Types
+      const entries: [string, any][] = Object.entries(schema.properties)
+
+      for (const [_, value] of entries) {
         if (
-          value !== undefined &&
-          // @ts-ignore
+          typeof value === 'object' &&
           value.type === 'string' &&
-          // @ts-ignore
           value.format === 'binary'
         ) {
-          // @ts-ignore
           value.contentEncoding = 'application/octet-stream'
-          // @ts-ignore
           delete value.format
         }
       }
-    }
-
-    return schema
-  })
-
-  // Uploading a binary file in a POST request
-  specification = traverse(specification, (schema) => {
-    if (schema.type === 'string' && schema.format === 'binary') {
-      return undefined
     }
 
     return schema

--- a/packages/openapi-parser/tests/openapi3-examples/3.0/fail/schemaProperties.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.0/fail/schemaProperties.test.ts
@@ -11,7 +11,6 @@ describe('schemaProperties', () => {
 
     expect(errors).not.toBe(undefined)
     expect(errors).not.toStrictEqual([])
-    // @ts-ignore
     expect(errors[0]?.message).toBe(
       'Can’t resolve external reference: ../resources/myobject.yml',
     )

--- a/packages/openapi-parser/tests/openapi3-examples/3.0/pass/cyclical.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.0/pass/cyclical.test.ts
@@ -46,10 +46,9 @@ describe('cyclical', () => {
     )
     const category =
       result.schema.components.schemas.top.properties.cat.properties
-    expect(
-      // @ts-ignore
-      category.subcategories.items.properties.subcategories.type,
-    ).toEqual('array')
+    expect(category.subcategories.items.properties.subcategories.type).toEqual(
+      'array',
+    )
   })
 
   it.todo('resolves circular dependencies in referenced files', async () => {


### PR DESCRIPTION
This PR deletes all `@ts-ignore` comments and all but one `@ts-expect-error` comments.

The remaining TypeScript error is caused by a package, that comes without types. It’s only used in the demo.

Doesn’t impact the published types.