### PR TITLE
fix: ajv import broken

### DIFF
--- a/.changeset/new-mice-occur.md
+++ b/.changeset/new-mice-occur.md
@@ -1,0 +1,5 @@
+---
+'@scalar/openapi-parser': patch
+---
+
+fix: ajv import broken in CJS environments

--- a/packages/openapi-parser/src/lib/Validator/Validator.ts
+++ b/packages/openapi-parser/src/lib/Validator/Validator.ts
@@ -1,6 +1,6 @@
 import Ajv04 from 'ajv-draft-04'
 import addFormats from 'ajv-formats'
-import Ajv2020 from 'ajv/dist/2020'
+import Ajv2020 from 'ajv/dist/2020.js'
 
 import {
   ERRORS,


### PR DESCRIPTION
I’ve received this error in a CommonJS environment:

> [ERROR] Client bundle compiled with errors therefore further build is impossible.
>
> Module not found: Error: Can't resolve 'ajv/dist/2020' in '/Users/hanspagel/Documents/Projects/scalar/node_modules/.pnpm/@scalar+openapi-parser@0.6.0/node_modules/@scalar/openapi-parser/dist/src/lib/Validator'
>
> Did you mean '2020.js'?
>
> BREAKING CHANGE: The request 'ajv/dist/2020' failed to resolve only because it was resolved as fully specified

This PR imports from *.js, this should fix the error.