### PR TITLE
fix: node prefix breaks old webpack setup

### DIFF
--- a/.changeset/bright-starfishes-hear.md
+++ b/.changeset/bright-starfishes-hear.md
@@ -1,0 +1,5 @@
+---
+'@scalar/openapi-parser': patch
+---
+
+fix: node prefix breaks old webpack setup

--- a/packages/openapi-parser/src/utils/load/plugins/readFilesPlugin.ts
+++ b/packages/openapi-parser/src/utils/load/plugins/readFilesPlugin.ts
@@ -1,4 +1,4 @@
-import fs from 'node:fs'
+import fs from 'fs'
 
 import { ERRORS } from '../../../configuration'
 import { dirname, join } from '../../../polyfills/path'


### PR DESCRIPTION
WIP: I’m not if it’s just the prefix that breaks Webpack yet. Need to test it.

I received this in a Docusaurus Webpack setup:

> Module build failed: UnhandledSchemeError: Reading from "node:fs" is not handled by plugins (Unhandled scheme).
> Webpack supports "data:" and "file:" URIs by default.
> You may need an additional plugin to handle "node:" URIs.

