### PR TITLE
fix: read files plugin export is wrong

### DIFF
--- a/.changeset/orange-shoes-know.md
+++ b/.changeset/orange-shoes-know.md
@@ -1,0 +1,5 @@
+---
+'@scalar/openapi-parser': patch
+---
+
+fix: read files export is wrong

--- a/packages/openapi-parser/package.json
+++ b/packages/openapi-parser/package.json
@@ -32,7 +32,7 @@
       "import": "./dist/src/utils/load/plugins/fetchUrls.js"
     },
     "./plugins/read-files": {
-      "import": "./dist/src/utils/load/plugins/fetchUrls.js"
+      "import": "./dist/src/utils/load/plugins/readFiles.js"
     }
   },
   "sideEffects": false,


### PR DESCRIPTION
What a dumb typo! Let’s fix this swiftly.