### PR TITLE
fix: type import broken, fixes #133

### DIFF
--- a/.changeset/tasty-lions-yawn.md
+++ b/.changeset/tasty-lions-yawn.md
@@ -1,0 +1,5 @@
+---
+'@scalar/openapi-parser': patch
+---
+
+fix: types import has wrong path

--- a/packages/openapi-parser/package.json
+++ b/packages/openapi-parser/package.json
@@ -23,7 +23,7 @@
   ],
   "main": "./dist/src/index.js",
   "module": "./dist/src/index.js",
-  "types": "./dist/index.d.ts",
+  "types": "./dist/src/index.d.ts",
   "exports": {
     ".": {
       "import": "./dist/src/index.js"


### PR DESCRIPTION
I don’t know why the type import seems to work in the demo and in `scalar/scalar`, but the path is just wrong.

I just tried to find a way to catch this in CI, which seemed straight-forward, but it’s all just passing.

Anyway, here is the quick fix. I’ll find a solution to prevent this in the future.