### PR TITLE
feat: throw on error

### DIFF
--- a/.changeset/thick-pumpkins-battle.md
+++ b/.changeset/thick-pumpkins-battle.md
@@ -1,0 +1,5 @@
+---
+'@scalar/openapi-parser': patch
+---
+
+feat: validate and dereference, throwOnError option

--- a/README.md
+++ b/README.md
@@ -128,6 +128,26 @@ const result = openapi()
   .get()
 ```
 
+### Then/Catch syntax
+
+If you’re more the then/catch type of guy, that’s fine:
+
+```ts
+import { validate } from '@scalar/openapi-parser'
+
+const specification = …
+
+validate(specification, {
+  throwOnError: true,
+})
+.then(result => {
+  // Success
+})
+.catch(error => {
+  // Failure
+})
+```
+
 ### Advanced: URL and file references
 
 You can reference other files, too. To do that, the parser needs to know what files are available.

--- a/packages/openapi-parser/src/configuration.ts
+++ b/packages/openapi-parser/src/configuration.ts
@@ -21,10 +21,10 @@ export const OpenApiVersions = Object.keys(
  * List of error messages used in the Validator
  */
 export const ERRORS = {
-  EMPTY_OR_INVALID: 'Cannot find JSON, YAML or filename in data',
+  EMPTY_OR_INVALID: 'Can’t find JSON, YAML or filename in data',
   // URI_MUST_BE_STRING: 'uri parameter or $id attribute must be a string',
   OPENAPI_VERSION_NOT_SUPPORTED:
-    'Cannot find supported Swagger/OpenAPI version in specification, version must be a string.',
+    'Can’t find supported Swagger/OpenAPI version in specification, version must be a string.',
   INVALID_REFERENCE: 'Can’t resolve reference: %s',
   EXTERNAL_REFERENCE_NOT_FOUND: 'Can’t resolve external reference: %s',
   FILE_DOES_NOT_EXIST: 'File does not exist: %s',

--- a/packages/openapi-parser/src/lib/Validator/Validator.ts
+++ b/packages/openapi-parser/src/lib/Validator/Validator.ts
@@ -8,7 +8,12 @@ import {
   type OpenApiVersion,
   OpenApiVersions,
 } from '../../configuration'
-import type { AnyObject, Filesystem, ValidateResult } from '../../types'
+import type {
+  AnyObject,
+  Filesystem,
+  ThrowOnErrorOption,
+  ValidateResult,
+} from '../../types'
 import { details as getOpenApiVersion } from '../../utils/details'
 import { resolveReferences } from '../../utils/resolveReferences'
 import { transformErrors } from '../../utils/transformErrors'
@@ -47,7 +52,7 @@ export class Validator {
    */
   async validate(
     filesystem: Filesystem,
-    options?: { throwOnError?: boolean },
+    options?: ThrowOnErrorOption,
   ): Promise<ValidateResult> {
     const entrypoint = filesystem.find((file) => file.isEntrypoint)
     const specification = entrypoint?.specification

--- a/packages/openapi-parser/src/lib/Validator/Validator.ts
+++ b/packages/openapi-parser/src/lib/Validator/Validator.ts
@@ -108,7 +108,7 @@ export class Validator {
       }
 
       // Check if the references are valid
-      const resolvedReferences = resolveReferences(filesystem)
+      const resolvedReferences = resolveReferences(filesystem, options)
 
       return {
         valid: schemaResult && resolvedReferences.valid,

--- a/packages/openapi-parser/src/lib/Validator/Validator.ts
+++ b/packages/openapi-parser/src/lib/Validator/Validator.ts
@@ -45,7 +45,10 @@ export class Validator {
   /**
    * Checks whether a specification is valid and all references can be resolved.
    */
-  async validate(filesystem: Filesystem): Promise<ValidateResult> {
+  async validate(
+    filesystem: Filesystem,
+    options?: { throwOnError?: boolean },
+  ): Promise<ValidateResult> {
     const entrypoint = filesystem.find((file) => file.isEntrypoint)
     const specification = entrypoint?.specification
 
@@ -61,6 +64,10 @@ export class Validator {
     try {
       // AnyObject is empty or invalid
       if (specification === undefined || specification === null) {
+        if (options?.throwOnError) {
+          throw new Error(ERRORS.EMPTY_OR_INVALID)
+        }
+
         return {
           valid: false,
           errors: transformErrors(entrypoint, ERRORS.EMPTY_OR_INVALID),
@@ -110,6 +117,10 @@ export class Validator {
       }
     } catch (error) {
       // Something went horribly wrong!
+      if (options?.throwOnError) {
+        throw error
+      }
+
       return {
         valid: false,
         errors: transformErrors(entrypoint, error.message ?? error),

--- a/packages/openapi-parser/src/pipeline.test.ts
+++ b/packages/openapi-parser/src/pipeline.test.ts
@@ -257,4 +257,56 @@ describe('pipeline', () => {
     expect(result.errors).toStrictEqual([])
     expect(result.schema.info.title).toBe('Hello World')
   })
+
+  it('throws an error when dereference fails', async () => {
+    expect(async () => {
+      await openapi({
+        throwOnError: true,
+      })
+        .load({
+          openapi: '3.1.0',
+          info: {},
+          paths: {
+            '/foobar': {
+              post: {
+                requestBody: {
+                  $ref: '#/components/requestBodies/DoesNotExist',
+                },
+              },
+            },
+          },
+        })
+        .dereference()
+        .get()
+    }).rejects.toThrowError(
+      'Can’t resolve reference: #/components/requestBodies/DoesNotExist',
+    )
+  })
+
+  it('throws an error when validate fails', async () => {
+    expect(async () => {
+      await openapi({
+        throwOnError: true,
+      })
+        .load({
+          openapi: '3.1.0',
+          info: {
+            title: 'Hello World',
+          },
+          paths: {
+            '/foobar': {
+              post: {
+                requestBody: {
+                  $ref: '#/components/requestBodies/DoesNotExist',
+                },
+              },
+            },
+          },
+        })
+        .validate()
+        .get()
+    }).rejects.toThrowError(
+      'Can’t resolve reference: #/components/requestBodies/DoesNotExist',
+    )
+  })
 })

--- a/packages/openapi-parser/src/pipeline.test.ts
+++ b/packages/openapi-parser/src/pipeline.test.ts
@@ -258,7 +258,7 @@ describe('pipeline', () => {
     expect(result.schema.info.title).toBe('Hello World')
   })
 
-  it('throws an error when dereference fails', async () => {
+  it('throws an error when dereference fails (global)', async () => {
     expect(async () => {
       await openapi({
         throwOnError: true,
@@ -283,7 +283,32 @@ describe('pipeline', () => {
     )
   })
 
-  it('throws an error when validate fails', async () => {
+  it('throws an error when dereference fails (only dereference)', async () => {
+    expect(async () => {
+      await openapi()
+        .load({
+          openapi: '3.1.0',
+          info: {},
+          paths: {
+            '/foobar': {
+              post: {
+                requestBody: {
+                  $ref: '#/components/requestBodies/DoesNotExist',
+                },
+              },
+            },
+          },
+        })
+        .dereference({
+          throwOnError: true,
+        })
+        .get()
+    }).rejects.toThrowError(
+      'Can’t resolve reference: #/components/requestBodies/DoesNotExist',
+    )
+  })
+
+  it('throws an error when validate fails (global)', async () => {
     expect(async () => {
       await openapi({
         throwOnError: true,
@@ -304,6 +329,33 @@ describe('pipeline', () => {
           },
         })
         .validate()
+        .get()
+    }).rejects.toThrowError(
+      'Can’t resolve reference: #/components/requestBodies/DoesNotExist',
+    )
+  })
+
+  it('throws an error when validate fails (only validate)', async () => {
+    expect(async () => {
+      await openapi()
+        .load({
+          openapi: '3.1.0',
+          info: {
+            title: 'Hello World',
+          },
+          paths: {
+            '/foobar': {
+              post: {
+                requestBody: {
+                  $ref: '#/components/requestBodies/DoesNotExist',
+                },
+              },
+            },
+          },
+        })
+        .validate({
+          throwOnError: true,
+        })
         .get()
     }).rejects.toThrowError(
       'Can’t resolve reference: #/components/requestBodies/DoesNotExist',

--- a/packages/openapi-parser/src/pipeline.test.ts
+++ b/packages/openapi-parser/src/pipeline.test.ts
@@ -361,4 +361,39 @@ describe('pipeline', () => {
       'Can’t resolve reference: #/components/requestBodies/DoesNotExist',
     )
   })
+
+  it('works with then & catch', async () => {
+    return new Promise((resolve, reject) => {
+      openapi()
+        .load({
+          openapi: '3.1.0',
+          info: {
+            title: 'Hello World',
+          },
+          paths: {
+            '/foobar': {
+              post: {
+                requestBody: {
+                  $ref: '#/components/requestBodies/DoesNotExist',
+                },
+              },
+            },
+          },
+        })
+        .validate({
+          throwOnError: true,
+        })
+        .get()
+        .then(() => {
+          reject()
+        })
+        .catch((error) => {
+          expect(error.message).toBe(
+            'Can’t resolve reference: #/components/requestBodies/DoesNotExist',
+          )
+
+          resolve(null)
+        })
+    })
+  })
 })

--- a/packages/openapi-parser/src/pipeline.ts
+++ b/packages/openapi-parser/src/pipeline.ts
@@ -1,4 +1,9 @@
-import type { AnyObject, DetailsResult, Filesystem } from './types'
+import type {
+  AnyObject,
+  DetailsResult,
+  Filesystem,
+  ThrowOnErrorOption,
+} from './types'
 import {
   dereference,
   details,
@@ -33,11 +38,6 @@ export type Queue = {
   specification: AnyApiDefinitionFormat
   tasks: Action[]
 }
-
-/**
- * If `true`, the function will throw an error if the document is invalid.
- */
-export type ThrowOnErrorOption = { throwOnError?: boolean }
 
 /**
  * JSON, YAML or object representation of an OpenAPI API definition

--- a/packages/openapi-parser/src/types/index.ts
+++ b/packages/openapi-parser/src/types/index.ts
@@ -69,3 +69,12 @@ export type FilesystemEntry = {
   filename: string
   specification: AnyObject
 }
+
+export type ThrowOnErrorOption = {
+  /**
+   * If `true`, the function will throw an error if the document is invalid.
+   *
+   * @default false
+   */
+  throwOnError?: boolean
+}

--- a/packages/openapi-parser/src/utils/dereference.test.ts
+++ b/packages/openapi-parser/src/utils/dereference.test.ts
@@ -2,8 +2,8 @@ import { describe, expect, it } from 'vitest'
 
 import { dereference } from './dereference'
 
-describe('resolve', async () => {
-  it('resolves an OpenAPI 3.1.0 file', async () => {
+describe('dereference', async () => {
+  it('dereferences an OpenAPI 3.1.0 file', async () => {
     const result = await dereference(`{
       "openapi": "3.1.0",
       "info": {
@@ -17,7 +17,7 @@ describe('resolve', async () => {
     expect(result.schema.info.title).toBe('Hello World')
   })
 
-  it('resolves an OpenAPI 3.0.0 file', async () => {
+  it('dereferences an OpenAPI 3.0.0 file', async () => {
     const result = await dereference(`{
       "openapi": "3.0.0",
       "info": {
@@ -31,7 +31,7 @@ describe('resolve', async () => {
     expect(result.schema.info.title).toBe('Hello World')
   })
 
-  it('resolves an Swagger 2.0 file', async () => {
+  it('dereferences an Swagger 2.0 file', async () => {
     const result = await dereference(`{
       "swagger": "2.0",
       "info": {
@@ -101,7 +101,7 @@ describe('resolve', async () => {
   })
 })
 
-it('resolves a simple reference', async () => {
+it('dereferences a simple reference', async () => {
   const openapi = {
     openapi: '3.1.0',
     info: {
@@ -167,4 +167,29 @@ it('resolves a simple reference', async () => {
       },
     },
   })
+})
+
+it('throws an error', async () => {
+  expect(async () => {
+    await dereference(
+      {
+        openapi: '3.1.0',
+        info: {},
+        paths: {
+          '/foobar': {
+            post: {
+              requestBody: {
+                $ref: '#/components/requestBodies/DoesNotExist',
+              },
+            },
+          },
+        },
+      },
+      {
+        throwOnError: true,
+      },
+    )
+  }).rejects.toThrowError(
+    'Can’t resolve reference: #/components/requestBodies/DoesNotExist',
+  )
 })

--- a/packages/openapi-parser/src/utils/dereference.ts
+++ b/packages/openapi-parser/src/utils/dereference.ts
@@ -9,11 +9,12 @@ import { resolveReferences } from './resolveReferences'
  */
 export async function dereference(
   value: string | AnyObject | Filesystem,
+  options?: { throwOnError?: boolean },
 ): Promise<DereferenceResult> {
   const filesystem = makeFilesystem(value)
 
   const entrypoint = getEntrypoint(filesystem)
-  const result = resolveReferences(filesystem)
+  const result = resolveReferences(filesystem, options)
 
   return {
     specification: entrypoint.specification,

--- a/packages/openapi-parser/src/utils/dereference.ts
+++ b/packages/openapi-parser/src/utils/dereference.ts
@@ -1,4 +1,9 @@
-import type { AnyObject, DereferenceResult, Filesystem } from '../types'
+import type {
+  AnyObject,
+  DereferenceResult,
+  Filesystem,
+  ThrowOnErrorOption,
+} from '../types'
 import { details } from './details'
 import { getEntrypoint } from './getEntrypoint'
 import { makeFilesystem } from './makeFilesystem'
@@ -9,7 +14,7 @@ import { resolveReferences } from './resolveReferences'
  */
 export async function dereference(
   value: string | AnyObject | Filesystem,
-  options?: { throwOnError?: boolean },
+  options?: ThrowOnErrorOption,
 ): Promise<DereferenceResult> {
   const filesystem = makeFilesystem(value)
 

--- a/packages/openapi-parser/src/utils/resolveReferences.ts
+++ b/packages/openapi-parser/src/utils/resolveReferences.ts
@@ -5,6 +5,7 @@ import type {
   ErrorObject,
   Filesystem,
   FilesystemEntry,
+  ThrowOnErrorOption,
 } from '../types'
 import { getEntrypoint } from './getEntrypoint'
 import { getSegmentsFromPath } from './getSegmentsFromPath'
@@ -38,10 +39,7 @@ export function resolveReferences(
   // Just a specification, or a set of files.
   input: AnyObject | Filesystem,
   // Additional options to control the behaviour
-  options?: {
-    // Throw an error if something goes wrong
-    throwOnError?: boolean
-  },
+  options?: ThrowOnErrorOption,
   // Fallback to the entrypoint
   file?: FilesystemEntry,
   // Errors that occurred during the process
@@ -159,7 +157,7 @@ function isCircular(schema: AnyObject) {
 function resolveUri(
   // 'foobar.json#/foo/bar'
   uri: string,
-  options: { throwOnError?: boolean },
+  options: ThrowOnErrorOption,
   // { filename: './foobar.json '}
   file: FilesystemEntry,
   // [ { filename: './foobar.json '} ]

--- a/packages/openapi-parser/src/utils/validate.test.ts
+++ b/packages/openapi-parser/src/utils/validate.test.ts
@@ -9,7 +9,7 @@ describe('validate', async () => {
     expect(result.valid).toBe(false)
     expect(result.errors).toMatchObject([
       {
-        message: 'Cannot find JSON, YAML or filename in data',
+        message: 'Can’t find JSON, YAML or filename in data',
       },
     ])
   })
@@ -37,7 +37,7 @@ describe('validate', async () => {
 
     expect(result.errors).toHaveLength(1)
     expect(result.errors[0].message).toBe(
-      'Cannot find supported Swagger/OpenAPI version in specification, version must be a string.',
+      'Can’t find supported Swagger/OpenAPI version in specification, version must be a string.',
     )
   })
 
@@ -64,7 +64,15 @@ paths: {}
 
     expect(result.errors).toHaveLength(1)
     expect(result.errors[0].message).toContain(
-      'Cannot find supported Swagger/OpenAPI version in specification',
+      'Can’t find supported Swagger/OpenAPI version in specification',
     )
+  })
+
+  it('throws an error', async () => {
+    expect(async () => {
+      await validate(undefined, {
+        throwOnError: true,
+      })
+    }).rejects.toThrowError('Can’t find JSON, YAML or filename in data')
   })
 })

--- a/packages/openapi-parser/src/utils/validate.ts
+++ b/packages/openapi-parser/src/utils/validate.ts
@@ -1,5 +1,11 @@
 import { Validator } from '../lib/Validator'
-import type { AnyObject, Filesystem, OpenAPI, ValidateResult } from '../types'
+import type {
+  AnyObject,
+  Filesystem,
+  OpenAPI,
+  ThrowOnErrorOption,
+  ValidateResult,
+} from '../types'
 import { makeFilesystem } from './makeFilesystem'
 
 /**
@@ -7,12 +13,7 @@ import { makeFilesystem } from './makeFilesystem'
  */
 export async function validate(
   value: string | AnyObject | Filesystem,
-  options?: {
-    /**
-     * If `true`, the function will throw an error if the document is invalid.
-     */
-    throwOnError?: boolean
-  },
+  options?: ThrowOnErrorOption,
 ): Promise<ValidateResult> {
   const filesystem = makeFilesystem(value)
 

--- a/packages/openapi-parser/src/utils/validate.ts
+++ b/packages/openapi-parser/src/utils/validate.ts
@@ -7,11 +7,17 @@ import { makeFilesystem } from './makeFilesystem'
  */
 export async function validate(
   value: string | AnyObject | Filesystem,
+  options?: {
+    /**
+     * If `true`, the function will throw an error if the document is invalid.
+     */
+    throwOnError?: boolean
+  },
 ): Promise<ValidateResult> {
   const filesystem = makeFilesystem(value)
 
   const validator = new Validator()
-  const result = await validator.validate(filesystem)
+  const result = await validator.validate(filesystem, options)
 
   return {
     ...result,


### PR DESCRIPTION
With this PR, we’re introducing the new option `throwOnError` which can be passed to `openapi()`, `validate()` and `dereference()` to make them throw an exception on the first error that they find.

The default is still to just deal with whatever is passed, but for some use cases we might want a stricter version.

Inspiration: #136

Note: This also adds the opportunity to add more options in the future. 👀 

```ts
import { validate } from '@scalar/openapi-parser'

const specification = …

validate(specification, {
  throwOnError: true,
})
.then(result => {
  // Success
})
.catch(error => {
  // Failure
})
```