### PR TITLE
feat: add a migration layer for `@apidevtools/swagger-parser`

### DIFF
--- a/packages/openapi-parser/src/configuration/index.ts
+++ b/packages/openapi-parser/src/configuration/index.ts
@@ -28,6 +28,7 @@ export const ERRORS = {
   INVALID_REFERENCE: 'Can’t resolve reference: %s',
   EXTERNAL_REFERENCE_NOT_FOUND: 'Can’t resolve external reference: %s',
   FILE_DOES_NOT_EXIST: 'File does not exist: %s',
+  NO_CONTENT: 'No content found',
 } as const
 
 export type VALIDATOR_ERROR = keyof typeof ERRORS

--- a/packages/openapi-parser/src/lib/Validator/Validator.ts
+++ b/packages/openapi-parser/src/lib/Validator/Validator.ts
@@ -89,6 +89,10 @@ export class Validator {
 
       // AnyObject is not supported
       if (!version) {
+        if (options?.throwOnError) {
+          throw new Error(ERRORS.OPENAPI_VERSION_NOT_SUPPORTED)
+        }
+
         return {
           valid: false,
           errors: transformErrors(
@@ -105,6 +109,10 @@ export class Validator {
       // Error handling
       if (validateSchema.errors) {
         if (validateSchema.errors.length > 0) {
+          if (options?.throwOnError) {
+            throw new Error(validateSchema.errors[0])
+          }
+
           return {
             valid: false,
             errors: transformErrors(entrypoint, validateSchema.errors),

--- a/packages/openapi-parser/src/types/index.ts
+++ b/packages/openapi-parser/src/types/index.ts
@@ -6,6 +6,7 @@ export type AnyObject = Record<string, any>
 
 export type LoadResult = {
   filesystem: Filesystem
+  errors?: ErrorObject[]
 }
 
 export type ValidateResult = {

--- a/packages/openapi-parser/src/utils/load/load.test.ts
+++ b/packages/openapi-parser/src/utils/load/load.test.ts
@@ -395,4 +395,26 @@ describe('load', async () => {
       },
     })
   })
+
+  it('returns an error', async () => {
+    const { errors } = await load('INVALID', {
+      plugins: [readFiles(), fetchUrls()],
+    })
+
+    expect(errors).toMatchObject([
+      {
+        code: 'EXTERNAL_REFERENCE_NOT_FOUND',
+        message: 'Can’t resolve external reference: INVALID',
+      },
+    ])
+  })
+
+  it('throws an error', async () => {
+    expect(async () => {
+      await load('INVALID', {
+        plugins: [readFiles(), fetchUrls()],
+        throwOnError: true,
+      })
+    }).rejects.toThrowError('Can’t resolve external reference: INVALID')
+  })
 })

--- a/packages/openapi-parser/src/utils/workThroughQueue.test.ts
+++ b/packages/openapi-parser/src/utils/workThroughQueue.test.ts
@@ -25,6 +25,7 @@ describe('workThroughQueue', () => {
     })
 
     expect(await result).toStrictEqual({
+      errors: [],
       filesystem: [
         {
           dir: './',
@@ -65,9 +66,9 @@ describe('workThroughQueue', () => {
     })
 
     expect(await result).toStrictEqual({
+      errors: [],
       valid: true,
       version: '3.1',
-      errors: [],
       filesystem: [
         {
           dir: './',
@@ -124,10 +125,10 @@ describe('workThroughQueue', () => {
     })
 
     expect(await result).toStrictEqual({
+      errors: [],
       specificationType: 'openapi',
       specificationVersion: '3.1.0',
       version: '3.1',
-      errors: [],
       filesystem: [
         {
           dir: './',
@@ -184,6 +185,7 @@ describe('workThroughQueue', () => {
     })
 
     expect(await result).toStrictEqual({
+      errors: [],
       version: '3.1',
       specification: {
         openapi: '3.1.0',

--- a/packages/openapi-parser/tests/migration-layer.json
+++ b/packages/openapi-parser/tests/migration-layer.json
@@ -1,0 +1,23 @@
+{
+    "openapi": "3.1.0",
+    "info": {
+      "title": "Hello World",
+      "version": "1.0.0"
+    },
+    "paths": {
+      "/foobar": {
+        "post": {
+          "requestBody": {
+            "$ref": "#/components/requestBodies/Foobar"
+          }
+        }
+      }
+    },
+    "components": {
+      "requestBodies": {
+        "Foobar": {
+          "content": {}
+        }
+      }
+    }
+  }

--- a/packages/openapi-parser/tests/migration-layer.test.ts
+++ b/packages/openapi-parser/tests/migration-layer.test.ts
@@ -42,13 +42,9 @@ class SwaggerParser {
 
       validate(filesystem, {
         throwOnError: true,
+      }).then((result) => {
+        callback(null, result.schema)
       })
-        .then((result) => {
-          callback(null, result.schema)
-        })
-        .catch((error) => {
-          callback(error, null)
-        })
     } catch (error) {
       callback(error, null)
     }

--- a/packages/openapi-parser/tests/migration-layer.test.ts
+++ b/packages/openapi-parser/tests/migration-layer.test.ts
@@ -1,16 +1,32 @@
 import OriginalSwaggerParser from '@apidevtools/swagger-parser'
 import { describe, expect, it } from 'vitest'
 
+import { dereference } from '../src/utils/dereference'
 import { validate } from '../src/utils/validate'
 
-const myAPI = `{
-    "openapi": "3.1.0",
-    "info": {
-        "title": "Hello World",
-        "version": "1.0.0"
+const myAPI = JSON.stringify({
+  openapi: '3.1.0',
+  info: {
+    title: 'Hello World',
+    version: '1.0.0',
+  },
+  paths: {
+    '/foobar': {
+      post: {
+        requestBody: {
+          $ref: '#/components/requestBodies/Foobar',
+        },
+      },
     },
-    "paths": {}
-}`
+  },
+  components: {
+    requestBodies: {
+      Foobar: {
+        content: {},
+      },
+    },
+  },
+})
 
 class SwaggerParser {
   static async validate(api: string, callback: (err: any, api: any) => void) {
@@ -24,10 +40,14 @@ class SwaggerParser {
         callback(error, null)
       })
   }
+
+  static async dereference(api: string) {
+    return dereference(api).then((result) => result.schema)
+  }
 }
 
 // https://github.com/APIDevTools/swagger-parser?tab=readme-ov-file#example
-describe('migration-layer', async () => {
+describe('validate', async () => {
   it('validates', async () => {
     return new Promise((resolve, reject) => {
       SwaggerParser.validate(myAPI, (err, api) => {
@@ -53,5 +73,16 @@ describe('migration-layer', async () => {
         }
       })
     })
+  })
+})
+
+// https://apitools.dev/swagger-parser/docs/swagger-parser.html#dereferenceapi-options-callback
+describe('dereference', () => {
+  it('dereferences', async () => {
+    let api = await SwaggerParser.dereference(myAPI)
+
+    // The `api` object is a normal JavaScript object,
+    // so you can easily access any part of the API using simple dot notation
+    expect(api?.paths?.['/foobar']?.post?.requestBody?.content).toEqual({})
   })
 })

--- a/packages/openapi-parser/tests/migration-layer.test.ts
+++ b/packages/openapi-parser/tests/migration-layer.test.ts
@@ -1,0 +1,57 @@
+import OriginalSwaggerParser from '@apidevtools/swagger-parser'
+import { describe, expect, it } from 'vitest'
+
+import { validate } from '../src/utils/validate'
+
+const myAPI = `{
+    "openapi": "3.1.0",
+    "info": {
+        "title": "Hello World",
+        "version": "1.0.0"
+    },
+    "paths": {}
+}`
+
+class SwaggerParser {
+  static async validate(api: string, callback: (err: any, api: any) => void) {
+    validate(api, {
+      throwOnError: true,
+    })
+      .then((result) => {
+        callback(null, result.schema)
+      })
+      .catch((error) => {
+        callback(error, null)
+      })
+  }
+}
+
+// https://github.com/APIDevTools/swagger-parser?tab=readme-ov-file#example
+describe('migration-layer', async () => {
+  it('validates', async () => {
+    return new Promise((resolve, reject) => {
+      SwaggerParser.validate(myAPI, (err, api) => {
+        if (err) {
+          reject(err)
+        } else {
+          expect(api.info.title).toBe('Hello World')
+          expect(api.info.version).toBe('1.0.0')
+
+          resolve(null)
+        }
+      })
+    })
+  })
+
+  it('throws an error for invalid documents', async () => {
+    return new Promise((resolve, reject) => {
+      SwaggerParser.validate('invalid', (err) => {
+        if (err) {
+          resolve(null)
+        } else {
+          reject()
+        }
+      })
+    })
+  })
+})


### PR DESCRIPTION
**Goal**
Making a drop-in replacement for the popular `@apidevtools/swagger-parser`.

**Tasks**
- [x] validate
- [x] dereference
- [x] load URLs
- [x] load files
- [ ] $refs
- [ ] bundle
- [ ] parse
- [ ] resolve
- [ ] options
- [ ] move to a separate package (name TBD `@scalar/apidevtools-swagger-parser`?)