### PR TITLE
feat: Add object name to parsed spec

### DIFF
--- a/packages/openapi-parser/src/utils/resolveReferences.ts
+++ b/packages/openapi-parser/src/utils/resolveReferences.ts
@@ -229,9 +229,13 @@ function resolveUri(
 
   // Try to find the URI
   try {
-    return segments.reduce((acc, key) => {
+    const result = segments.reduce((acc, key) => {
       return acc[key]
     }, file.specification)
+
+    result['x-object-name'] = segments[segments.length - 1]
+    
+    return result
   } catch (error) {
     if (options?.throwOnError) {
       throw new Error(ERRORS.INVALID_REFERENCE.replace('%s', uri))

--- a/packages/openapi-parser/src/utils/resolveReferences.ts
+++ b/packages/openapi-parser/src/utils/resolveReferences.ts
@@ -234,7 +234,7 @@ function resolveUri(
     }, file.specification)
 
     result['x-object-name'] = segments[segments.length - 1]
-    
+
     return result
   } catch (error) {
     if (options?.throwOnError) {


### PR DESCRIPTION
**Problem**
Currently, the object name of nested objects are lost when parsing the open API spec which means it cannot be displayed in Scalar.

See: https://github.com/scalar/scalar/discussions/2419

**Solution**
With this PR the object name has been added to the parsed spec on the property `x-object-name` let me know what name would be appropriate and if this is the correct approach to add this information to the parsed model. This is my first time looking into Scalar so I've no idea if this is the right way to add this information 😅 

**Test data**
![image](https://github.com/scalar/openapi-parser/assets/24605285/64bde827-9f40-48e6-a022-418290c653ef)

https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.yaml
