### PR TITLE
fix(openapi-parser): add TypeScript discriminator strings

### DIFF
--- a/.changeset/beige-spiders-grin.md
+++ b/.changeset/beige-spiders-grin.md
@@ -1,0 +1,5 @@
+---
+'@scalar/openapi-parser': patch
+---
+
+Add literal versions to OpenAPI.Document types

--- a/.changeset/beige-spiders-grin.md
+++ b/.changeset/beige-spiders-grin.md
@@ -2,4 +2,4 @@
 '@scalar/openapi-parser': patch
 ---
 
-Add literal versions to OpenAPI.Document types
+feat: add literal versions to OpenAPI.Document types

--- a/packages/openapi-parser/src/types/openapi-types.ts
+++ b/packages/openapi-parser/src/types/openapi-types.ts
@@ -56,7 +56,10 @@ export namespace OpenAPIV3_1 {
   export type Document<T extends {} = {}> = Modify<
     Omit<OpenAPIV3.Document<T>, 'paths' | 'components'>,
     {
-      /** Version of the OpenAPI specification */
+      /**
+       * Version of the OpenAPI specification
+       * @see https://github.com/OAI/OpenAPI-Specification/tree/main/versions
+       */
       openapi: '3.1.0'
       info?: InfoObject
       jsonSchemaDialect?: string
@@ -281,7 +284,10 @@ export namespace OpenAPIV3_1 {
 export namespace OpenAPIV3 {
   export interface Document<T extends {} = {}> {
     [propName: string]: any
-    /** Version of the OpenAPI specification */
+    /**
+     * Version of the OpenAPI specification
+     * @see https://github.com/OAI/OpenAPI-Specification/tree/main/versions
+     */
     openapi?: '3.0.0' | '3.0.1' | '3.0.2' | '3.0.2'
     info?: InfoObject
     servers?: ServerObject[]
@@ -620,6 +626,10 @@ export namespace OpenAPIV2 {
     schemes?: string[]
     security?: SecurityRequirementObject[]
     securityDefinitions?: SecurityDefinitionsObject
+    /**
+     * Version of the OpenAPI specification
+     * @see https://github.com/OAI/OpenAPI-Specification/tree/main/versions
+     */
     swagger?: '2.0'
     tags?: TagObject[]
   }

--- a/packages/openapi-parser/src/types/openapi-types.ts
+++ b/packages/openapi-parser/src/types/openapi-types.ts
@@ -18,14 +18,8 @@ export namespace OpenAPI {
       // any other attribute
       [key: string]: any
     } = {},
-  > = (
-    | OpenAPIV2.Document<T>
-    | OpenAPIV3.Document<T>
-    | OpenAPIV3_1.Document<T>
-  ) & {
-    // any other attribute
-    [key: string]: any
-  }
+  > = OpenAPIV2.Document<T> | OpenAPIV3.Document<T> | OpenAPIV3_1.Document<T>
+
   export type Operation<T extends {} = {}> =
     | OpenAPIV2.OperationObject<T>
     | OpenAPIV3.OperationObject<T>
@@ -62,6 +56,8 @@ export namespace OpenAPIV3_1 {
   export type Document<T extends {} = {}> = Modify<
     Omit<OpenAPIV3.Document<T>, 'paths' | 'components'>,
     {
+      /** Version of the OpenAPI specification */
+      openapi: '3.1.0'
       info?: InfoObject
       jsonSchemaDialect?: string
       servers?: ServerObject[]
@@ -284,7 +280,9 @@ export namespace OpenAPIV3_1 {
 
 export namespace OpenAPIV3 {
   export interface Document<T extends {} = {}> {
-    openapi?: string
+    [propName: string]: any
+    /** Version of the OpenAPI specification */
+    openapi?: '3.0.0' | '3.0.1' | '3.0.2' | '3.0.2'
     info?: InfoObject
     servers?: ServerObject[]
     paths?: PathsObject<T>
@@ -606,6 +604,9 @@ export namespace OpenAPIV3 {
 
 export namespace OpenAPIV2 {
   export interface Document<T extends {} = {}> {
+    [propName: string]: any
+    /** To make it easier to use openapi as a type guard */
+    openapi: undefined
     basePath?: string
     consumes?: MimeTypes
     definitions?: DefinitionsObject
@@ -619,7 +620,7 @@ export namespace OpenAPIV2 {
     schemes?: string[]
     security?: SecurityRequirementObject[]
     securityDefinitions?: SecurityDefinitionsObject
-    swagger?: string
+    swagger?: '2.0'
     tags?: TagObject[]
   }
 


### PR DESCRIPTION
- Fixes #158

**Problem**
Currently, it's hard to figure out what version of OpenAPI spec you've got, and the spec types are combined together, which makes it hard to interact with the schema object.

**Explanation**
This happens because the types for the documents don't have literal version strings, and the way they're combined mushes them together.

**Solution**
With this PR each OpenAPI version gets a literal version string and the types are combined in a simpler way.